### PR TITLE
Changed the types in the Routing. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### 0.2.8
 
+#### Changes
+* Changed the types in the Routing. In most cases these are still compatible because utility methods are used.
+
+Before:
+Route: Request => FXFuture[Response]
+Now:
+Route: Request => Response
+Response: FXFuture[ResponseResult]
+
+This made the API more easy to use by hiding complexity which is only needed in rare cases.
+* Fixed parts of the `Route.when` api, which had unexpected argument types.
+* Removed `ResponseUtils.redirect` and replaced it with `Response.redirect` and also added `Response.fromNode`
+
 #### Improvements
 * Updated JPro to version `2023.3.3`.
 * Added `login` example for JPro Auth modules. This example shows how to use the JPro Auth modules to authenticate
@@ -9,10 +22,6 @@
 * Added `jpro-auth-routing` module to the platform that provides the API to simplify the combination of  routing 
   capabilities during the authentication process. Simultaneously, `jpro-auth` module was renamed to `jpro-auth-core`
   and everything under `one.jpro.platform.auth` package was moved to `one.jpro.platform.auth.core` package.
-
-#### Changes
-* Fixed parts of the `Route.when` api, which had unexpected argument types.
-* Removed `ResponseUtils.redirect` and replaced it with `Response.redirect` and also added `Response.fromNode`
 
 ### 0.2.7 (December 8, 2023)
 

--- a/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/login/LoginApp.java
+++ b/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/login/LoginApp.java
@@ -82,8 +82,8 @@ public class LoginApp extends RouteApp {
                 .filter(DevFilter.create())
                 .filter(OAuth2Filter.create(googleAuthProvider, googleCredentials, user -> {
                     setUser(user);
-                    return Response.redirectFuture("/user/signed-in");
-                }, error -> Response.fromNodeFuture(new ErrorPage(error))));
+                    return Response.redirect("/user/signed-in");
+                }, error -> Response.node(new ErrorPage(error))));
     }
 
     public final User getUser() {

--- a/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/oauth/OAuthApp.java
+++ b/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/oauth/OAuthApp.java
@@ -8,6 +8,7 @@ import one.jpro.platform.auth.example.oauth.page.*;
 import one.jpro.platform.auth.routing.OAuth2Filter;
 import one.jpro.platform.routing.Filter;
 import one.jpro.platform.routing.Redirect;
+import one.jpro.platform.routing.Response;
 import one.jpro.platform.routing.Route;
 import one.jpro.platform.routing.dev.DevFilter;
 import one.jpro.platform.routing.dev.StatisticsFilter;
@@ -109,10 +110,10 @@ public class OAuthApp extends BaseOAuthApp {
         return OAuth2Filter.create(authProvider, credentials, user -> {
             setUser(user);
             setAuthProvider(authProvider);
-            return FXFuture.unit(new Redirect(USER_CONSOLE_PATH));
+            return Response.redirect(USER_CONSOLE_PATH);
         }, error -> {
             setError(error);
-            return FXFuture.unit(new Redirect(AUTH_ERROR_PATH));
+            return Response.redirect(AUTH_ERROR_PATH);
         });
     }
 }

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/JWTFilter.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/JWTFilter.java
@@ -48,10 +48,10 @@ public interface JWTFilter {
 
         return (route) -> (request) -> {
             if (request.path().equals(authPath)) {
-                return FXFuture.fromJava(authProvider.token(tokenPath, credentials)
+                return Response.fromFuture(FXFuture.fromJava(authProvider.token(tokenPath, credentials)
                                 .thenCompose(authProvider::authenticate))
                         .flatMap(userFunction::apply)
-                        .flatExceptionally(errorFunction::apply);
+                        .flatExceptionally(errorFunction::apply));
             } else {
                 return route.apply(request);
             }

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestAppCrawler.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestAppCrawler.scala
@@ -35,8 +35,8 @@ class TestAppCrawler {
   def testCrawlApp(): Unit = {
     def app = new RouteNode(null) {
       setRoute(Route.empty()
-        .and(RouteUtils.get("/", r => new Page1))
-        .and(RouteUtils.get("/page2", r => new Page2)))
+        .and(RouteUtils.getView("/", r => new Page1))
+        .and(RouteUtils.getView("/page2", r => new Page2)))
     }
     val result = AppCrawler.crawlApp("http://localhost", () => app)
 
@@ -50,7 +50,7 @@ class TestAppCrawler {
   def testEmptyImage(): Unit = {
     def app = new RouteNode(null) {
       setRoute(Route.empty()
-        .and(RouteUtils.get("/", r => new View {
+        .and(RouteUtils.getView("/", r => new View {
           override def title: String = ""
 
           override def description: String = ""

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestMemoryTester.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestMemoryTester.scala
@@ -14,9 +14,9 @@ class TestMemoryTester {
   def simpleTest(): Unit = {
     def app = new RouteNode(null) {
       setRoute(Route.empty()
-        .and(get("/", r => new Page1))
-        .and(get("/page2", r => new Page2))
-        .and(get("/page4", r => new Page2)))
+        .and(getView("/", r => new Page1))
+        .and(getView("/page2", r => new Page2))
+        .and(getView("/page4", r => new Page2)))
     }
     val result = AppCrawler.crawlApp("http://localhost", () => app)
     MemoryTester.testForLeaks(result, () => app)
@@ -27,9 +27,9 @@ class TestMemoryTester {
     val page2 = new Page2
     def app = new RouteNode(null) {
       setRoute(Route.empty()
-        .and(get("/", r => new Page1))
-        .and(get("/page2", r => page2))
-        .and(get("/page4", r => new Page2)))
+        .and(getView("/", r => new Page1))
+        .and(getView("/page2", r => page2))
+        .and(getView("/page4", r => new Page2)))
     }
     val result = AppCrawler.crawlApp("http://localhost", () => app)
     intercept[Throwable](MemoryTester.testForLeaks(result, () => app))
@@ -41,9 +41,9 @@ class TestMemoryTester {
 
     def app = new RouteNode(null) {
       setRoute(Route.empty()
-        .and(get("/", r => new Page1))
-        .and(get("/page2", r => viewFromNode(node2)))
-        .and(get("/page4", r => new Page2)))
+        .and(getView("/", r => new Page1))
+        .and(getView("/page2", r => viewFromNode(node2)))
+        .and(getView("/page4", r => new Page2)))
     }
 
     val result = AppCrawler.crawlApp("http://localhost", () => app)
@@ -54,9 +54,9 @@ class TestMemoryTester {
   def simpleFailingTest3(): Unit = {
     val app = inFX(new RouteNode(null) {
       setRoute(Route.empty()
-        .and(get("/", r => new Page1))
-        .and(get("/page2", r => new Page2))
-        .and(get("/page4", r => new Page2)))
+        .and(getView("/", r => new Page1))
+        .and(getView("/page2", r => new Page2))
+        .and(getView("/page4", r => new Page2)))
     })
     val result = AppCrawler.crawlApp("http://localhost", () => app)
     intercept[Throwable](MemoryTester.testForLeaks(result, () => app)) // fails because the webapp is not collectable

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestSitemapGenerator.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestSitemapGenerator.scala
@@ -2,7 +2,7 @@ package one.jpro.platform.routing.crawl
 
 import one.jpro.platform.routing.RouteUtils._
 import one.jpro.platform.routing.crawl.TestUtils._
-import one.jpro.platform.routing.{Redirect, Route, RouteNode}
+import one.jpro.platform.routing.{Redirect, Response, Route, RouteNode}
 import org.junit.jupiter.api.Test
 import simplefx.experimental._
 
@@ -11,10 +11,10 @@ class TestSitemapGenerator {
   def test(): Unit = {
     def app = new RouteNode(null) {
       setRoute(Route.empty()
-        .and(get("/", r => new Page1))
-        .and(get("/page2", r => new Page2))
-        .and(get("/page4", r => new Page2))
-        .and(r => FXFuture.unit(new Page1)))
+        .and(getView("/", r => new Page1))
+        .and(getView("/page2", r => new Page2))
+        .and(getView("/page4", r => new Page2))
+        .and(r => Response.view(new Page1)))
     }
     val result = AppCrawler.crawlApp("http://localhost", () => app)
     val sm = SitemapGenerator.createSitemap("http://localhost", result)
@@ -28,8 +28,8 @@ class TestSitemapGenerator {
   def testMailToRedirect(): Unit = {
     def app = new RouteNode(null) {
       setRoute(Route.empty()
-        .and(get("/", r => pageWithLink(List("/page2", "/page3", "mailto:something"))))
-        .and(get("/page2", r => new Redirect("mailto:something-2"))))
+        .and(getView("/", r => pageWithLink(List("/page2", "/page3", "mailto:something"))))
+        .and(get("/page2", r => Response.redirect("mailto:something-2"))))
     }
     val result = AppCrawler.crawlApp("http://localhost", () => app)
     println("got result: " + result)

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Filters.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Filters.scala
@@ -5,8 +5,8 @@ import simplefx.all
 object Filters {
   def FullscreenFilter(fullscreenValue: Boolean): Filter = { route => { request =>
       val r = route.apply(request)
-      if(r == null) null
-      else r.map {
+
+      Response(r.future.map {
         case x: View =>
           new View {
             override def title: String = x.title
@@ -16,7 +16,7 @@ object Filters {
             override def fullscreen: Boolean = fullscreenValue
           }
         case x => x
-      }
+      })
     }
   }
 

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Redirect.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Redirect.scala
@@ -1,3 +1,3 @@
 package one.jpro.platform.routing
 
-case class Redirect(to: String) extends Response
+case class Redirect(to: String) extends ResponseResult

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Response.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Response.scala
@@ -2,14 +2,15 @@ package one.jpro.platform.routing
 
 import simplefx.experimental.FXFuture
 
-trait Response
+case class Response(future: FXFuture[ResponseResult]) {
+  assert(future != null, "future must not be null - but it's value can be null")
+}
 object Response {
-  def empty(): Response = null
-  def emptyFuture(): FXFuture[Response] = FXFuture.unit(empty())
-  def redirect(to: String): Response = Redirect(to)
-  def redirectFuture(to: String): FXFuture[Response] = FXFuture.unit(Redirect(to))
-  def fromNode(node: javafx.scene.Node): Response = new Response {
-    RouteUtils.viewFromNode(node)
-  }
-  def fromNodeFuture(node: javafx.scene.Node): FXFuture[Response] = FXFuture.unit(fromNode(node))
+  def empty(): Response = Response(FXFuture.unit(null))
+  def redirect(to: String): Response = Response(FXFuture.unit(Redirect(to)))
+
+  def view(view: View): Response = Response(FXFuture.unit(view))
+  def node(node: javafx.scene.Node): Response = Response(FXFuture.unit(View.fromNode(node)))
+  def fromFuture(future: FXFuture[Response]): Response = Response(future.flatMap(_.future))
+  def fromFutureResult(future: FXFuture[ResponseResult]): Response = Response(future)
 }

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/ResponseResult.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/ResponseResult.scala
@@ -1,0 +1,3 @@
+package one.jpro.platform.routing
+
+trait ResponseResult

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/RouteUtils.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/RouteUtils.scala
@@ -11,7 +11,7 @@ object RouteUtils {
 
   def redirect(path: String, to: String): Route = get(path, (r) => Response.redirect(to))
 
-  def get(path: String, f: Function[Request, Response]): Route = (request: Request) => if (request.path == path) f.apply(request) else null
+  def get(path: String, f: Function[Request, Response]): Route = (request: Request) => if (request.path == path) f.apply(request) else Response.empty()
 
   def getView(path: String, node: Function[Request, View]): Route = (request: Request) => {
     if (request.path == path) Response.view(node.apply(request))

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/RouteUtils.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/RouteUtils.scala
@@ -9,22 +9,22 @@ import java.util.function.Function
 
 object RouteUtils {
 
-  @deprecated
-  val EmptyRoute: Route = (x) => null
+  def redirect(path: String, to: String): Route = get(path, (r) => Response.redirect(to))
 
-  def redirect(path: String, to: String): Route = get(path, (r) => Redirect(to))
+  def get(path: String, f: Function[Request, Response]): Route = (request: Request) => if (request.path == path) f.apply(request) else null
 
-  def getFuture(path: String, f: Function[Request, FXFuture[Response]]): Route = (request: Request) => if (request.path == path) f.apply(request) else FXFuture.unit(null)
-
-  def get(path: String, f: Function[Request, Response]): Route = (request: Request) => if (request.path == path) FXFuture.unit(f.apply(request)) else null
-
-  def getNodeFuture(path: String, node: Function[Request, FXFuture[Node]]): Route = (request: Request) => if (request.path == path) node.apply(request).map(node => viewFromNode(node)) else FXFuture.unit(null)
-
-  def getNode(path: String, node: Function[Request, Node]): Route = (request: Request) => if (request.path == path) FXFuture.unit(viewFromNode(node.apply(request))) else null
+  def getView(path: String, node: Function[Request, View]): Route = (request: Request) => {
+    if (request.path == path) Response.view(node.apply(request))
+    else Response.empty()
+  }
+  def getNode(path: String, node: Function[Request, Node]): Route = (request: Request) => {
+    if (request.path == path) Response.node(node.apply(request))
+    else Response.empty()
+  }
 
 
   def transitionFilter(seconds: Double): Filter = route => { request => {
-    route.apply(request).map{
+    Response(route.apply(request).future.map{
       case x: View =>
         val oldNode = request.oldContent.get()
         val newNode = x.realContent
@@ -41,10 +41,10 @@ object RouteUtils {
           x.mapContent(x => res)
         }
       case x => x
-    }
+    })
   }}
   def sideTransitionFilter(seconds: Double): Filter = route => { request => {
-    route.apply(request).map{
+    Response(route.apply(request).future.map{
       case x: View =>
         val oldNode = request.oldContent.get()
         val newNode = x.realContent
@@ -70,10 +70,8 @@ object RouteUtils {
           x.mapContent(x => res)
         }
       case x => x
-    }
+    })
   }}
-
-  def mapViewFilter(request: Request, f: Node => Node): View = ???
 
   def viewFromNode(x: Node): View = new View {
     override def title: String = "view-from-node"

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/View.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/View.scala
@@ -4,7 +4,10 @@ import one.jpro.platform.routing.sessionmanager.SessionManager
 import simplefx.all
 import simplefx.all._
 
-abstract class View extends Response { THIS =>
+object View {
+  def fromNode(node: javafx.scene.Node): View = RouteUtils.viewFromNode(node)
+}
+abstract class View extends ResponseResult { THIS =>
   def title: String
   def description: String
   var url: String = null

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/AppCrawler.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/AppCrawler.scala
@@ -1,7 +1,7 @@
 package one.jpro.platform.routing.crawl
 
 import one.jpro.platform.routing.sessionmanager.DummySessionManager
-import one.jpro.platform.routing.{Redirect, RouteNode, SessionManagerContext, View}
+import one.jpro.platform.routing.{Redirect, Response, RouteNode, SessionManagerContext, View}
 import org.slf4j.{Logger, LoggerFactory}
 import simplefx.all._
 import simplefx.core._
@@ -113,10 +113,8 @@ object AppCrawler {
       toIndex -= crawlNext
       indexed += crawlNext
       val result = inFX {
-        val r = createApp.get().route(crawlNext)
-        if(r == null) FXFuture.unit(null)
-        else r
-      }.await
+        createApp.get().route(crawlNext)
+      }.future.await
       result match {
         case Redirect(url) =>
           redirects += crawlNext

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/MemoryTester.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/MemoryTester.scala
@@ -19,7 +19,7 @@ object MemoryTester {
         JMemoryBuddy.memoryTest(checker2 => {
           val factory = inFX(appFactory.get())
           assert(factory != null, "The appFactory must not return null")
-          val view = inFX(appFactory.get().route(pageURL)).await
+          val view = inFX(appFactory.get().route(pageURL)).future.await
 
           checker2.setAsReferenced(factory)
           checker2.assertCollectable(view) // Hm?

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/ContainerFilter.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/ContainerFilter.scala
@@ -1,6 +1,6 @@
 package one.jpro.platform.routing.filter.container
 
-import one.jpro.platform.routing.{Filter, Request, View}
+import one.jpro.platform.routing.{Filter, Request, Response, View}
 import org.slf4j.{Logger, LoggerFactory}
 import simplefx.all._
 
@@ -48,8 +48,7 @@ object ContainerFilter {
       }
     }
     val r = route(request2)
-    if (r == null) null
-    else r.map {
+    Response(r.future.map {
       case view: View =>
         if (container == null) {
           container = containerLogic.createContainer()
@@ -60,6 +59,6 @@ object ContainerFilter {
           container
         })
       case x => x
-    }
+    })
   }
 }

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/DummySessionManager.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/DummySessionManager.scala
@@ -1,6 +1,6 @@
 package one.jpro.platform.routing.sessionmanager
 
-import one.jpro.platform.routing.{Response, RouteNode}
+import one.jpro.platform.routing.{Response, ResponseResult, RouteNode}
 
 class DummySessionManager extends SessionManager {
   override def webApp: RouteNode = null
@@ -9,9 +9,9 @@ class DummySessionManager extends SessionManager {
 
   override def goForward(): Unit = ()
 
-  override def gotoURL(_url: String, x: Response, pushState: Boolean, track: Boolean): Unit = ()
+  override def gotoURL(_url: String, x: ResponseResult, pushState: Boolean, track: Boolean): Unit = ()
 
-  override def getView(url: String): _root_.simplefx.experimental.FXFuture[Response] = null
+  override def getView(url: String): Response = Response.empty()
 
   override def start(): Unit = ()
 }

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManagerDesktop.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManagerDesktop.scala
@@ -25,7 +25,7 @@ class SessionManagerDesktop(val webApp: RouteNode) extends SessionManager { THIS
     gotoURL(historyCurrent.path, false, true)
   }
 
-  def gotoURL(_url: String, x: Response, pushState: Boolean, track: Boolean): Unit = {
+  def gotoURL(_url: String, x: ResponseResult, pushState: Boolean, track: Boolean): Unit = {
     x match {
       case Redirect(url) =>
         logger.debug(s"redirect: ${_url} -> $url")

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManagerWeb.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManagerWeb.scala
@@ -1,7 +1,7 @@
 package one.jpro.platform.routing.sessionmanager
 
 import com.jpro.webapi.WebAPI
-import one.jpro.platform.routing.{Redirect, Response, RouteNode, View}
+import one.jpro.platform.routing.{Redirect, Response, ResponseResult, RouteNode, View}
 import org.slf4j.{Logger, LoggerFactory}
 import simplefx.all._
 
@@ -27,7 +27,7 @@ class SessionManagerWeb(val webApp: RouteNode, val webAPI: WebAPI) extends Sessi
     markViewCollectable(THIS.view)
   })
 
-  def gotoURL(_url: String, x: Response, pushState: Boolean, track: Boolean): Unit = {
+  def gotoURL(_url: String, x: ResponseResult, pushState: Boolean, track: Boolean): Unit = {
     assert(x != null, "Response was null for url: " + _url)
     val url = _url
     x match {

--- a/jpro-routing/example/src/main/java/example/colors/ColorsApp.java
+++ b/jpro-routing/example/src/main/java/example/colors/ColorsApp.java
@@ -40,9 +40,9 @@ public class ColorsApp extends RouteApp {
               if(matcher.matches()) {
                 var colorStr = matcher.group(1);
                 var color = Color.web(colorStr);
-                return Response.fromNodeFuture(gen("#" + colorStr, r.resolve("/red"), color));
+                return Response.node(gen("#" + colorStr, r.resolve("/red"), color));
               } else {
-                return Response.emptyFuture();
+                return Response.empty();
               }
             })
             .path("/colors",

--- a/jpro-routing/example/src/main/scala/example/scala/TestWebApplication.scala
+++ b/jpro-routing/example/src/main/scala/example/scala/TestWebApplication.scala
@@ -19,27 +19,27 @@ class MyApp(stage: Stage) extends RouteNode(stage) {
 
   setRoute(
     Route.empty()
-      .and(get("", (r) => new MainView))
-      .and(get("/", (r) => new MainView))
-      .and(get("/redirect2", (r) => Redirect("https://google.com")))
-      .and(get("/main", (r) => new MainView))
-      .and(get("/green", (r) => new GreenView))
-      .and(get("/sub", (r) => new SubView))
-      .and(get("/redirect", (r) => Redirect("/sub")))
-      .and(get("/paralax", (r) => new ParalaxPage))
-      .and(get("/pdf", (r) => new PDFTest))
-      .and(get("/leak", (r) => new LeakingPage))
-      .and(get("/collect", (r) => new CollectingPage))
-      .and(get("/jmemorybuddy", (r) => new JMemoryBuddyPage))
-      .and(get("/100", (r) => new ManyNodes(100)))
-      .and(get("/200", (r) => new ManyNodes(200)))
-      .and(get("/400", (r) => new ManyNodes(400)))
-      .and(get("/800", (r) => new ManyNodes(800)))
-      .and(get("/1600", (r) => new ManyNodes(1600)))
-      .and(get("/3200", (r) => new ManyNodes(3200)))
-      .and(get("/6400", (r) => new ManyNodes(6400)))
-      .and(get("/it's\" tricky", (r) => new MainView))
-      .and(get("/it's\" tricky", (r) => new MainView))
+      .and(getView("", (r) => new MainView))
+      .and(getView("/", (r) => new MainView))
+      .and(get("/redirect2", r => Response.redirect("https://google.com")))
+      .and(getView("/main", (r) => new MainView))
+      .and(getView("/green", (r) => new GreenView))
+      .and(getView("/sub", (r) => new SubView))
+      .and(get("/redirect", r => Response.redirect( "/sub")))
+      .and(getView("/paralax", (r) => new ParalaxPage))
+      .and(getView("/pdf", (r) => new PDFTest))
+      .and(getView("/leak", (r) => new LeakingPage))
+      .and(getView("/collect", (r) => new CollectingPage))
+      .and(getView("/jmemorybuddy", (r) => new JMemoryBuddyPage))
+      .and(getView("/100", (r) => new ManyNodes(100)))
+      .and(getView("/200", (r) => new ManyNodes(200)))
+      .and(getView("/400", (r) => new ManyNodes(400)))
+      .and(getView("/800", (r) => new ManyNodes(800)))
+      .and(getView("/1600", (r) => new ManyNodes(1600)))
+      .and(getView("/3200", (r) => new ManyNodes(3200)))
+      .and(getView("/6400", (r) => new ManyNodes(6400)))
+      .and(getView("/it's\" tricky", (r) => new MainView))
+      .and(getView("/it's\" tricky", (r) => new MainView))
       .filter(DevFilter.create)
       .filter(StatisticsFilter.create)
   )
@@ -103,6 +103,12 @@ class Header2(view: View, sessionManager: SessionManager) extends HBox {
     disable <-- (!WebAPI.isBrowser && sessionManager.historyForward.isEmpty)
     onAction --> {
       goForward(this)
+    }
+  }
+  this <++ new Button("Backward2") {
+    onAction --> { e =>
+      println("view.getSessionManager(): " + view.getSessionManager())
+      view.getSessionManager().goBack()
     }
   }
 }

--- a/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/videoroom/VideoRoomApp.java
+++ b/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/videoroom/VideoRoomApp.java
@@ -1,9 +1,6 @@
 package one.jpro.platform.webrtc.example.videoroom;
 
-import one.jpro.platform.routing.Filters;
-import one.jpro.platform.routing.Route;
-import one.jpro.platform.routing.RouteApp;
-import one.jpro.platform.routing.RouteUtils;
+import one.jpro.platform.routing.*;
 import one.jpro.platform.webrtc.example.videoroom.page.OverviewPage;
 import one.jpro.platform.webrtc.example.videoroom.page.VideoRoomPage;
 import simplefx.experimental.parts.FXFuture;
@@ -30,9 +27,9 @@ public class VideoRoomApp extends RouteApp {
                     var matcher = roomPattern.matcher(r.path());
                     if(matcher.matches()) {
                         var roomID = matcher.group(1);
-                        return FXFuture.unit(viewFromNode(new VideoRoomPage(roomID, getWebAPI())));
+                        return Response.node(new VideoRoomPage(roomID, getWebAPI()));
                     } else {
-                        return FXFuture.unit(null);
+                        return Response.empty();
                     }
                 })
                 .filter(Filters.FullscreenFilter(true));


### PR DESCRIPTION
In most cases these are still compatible because utility methods are used.

Before:
Route: Request => FXFuture[Response]
Now:
Route: Request => Response
Response: FXFuture[ResponseResult]

This made the API more easy to use by hiding complexity which is only needed in rare cases.