### PR TITLE
Add Filters.styleClasses, rename Filters.css to Filters.stylesheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 #### Features
-* Added `Filters.css(...)` (and `CssFilter`) for scoping stylesheets to a route subtree — attached to the wrapper container `Parent`, not the `Scene`, so per-route CSS cannot bleed into siblings. Reactive via `ObservableList[String]` for runtime swaps (responsive, theme switching).
+* Added `Filters.stylesheets(...)` and `Filters.styleClasses(...)` for scoping stylesheets and style classes to a route subtree. Both attach to the wrapper container `Parent` (not the `Scene`), so per-route values cannot bleed into siblings. Reactive via `ObservableList[String]`, plus a Scala-only by-name overload (`=> List[String]`) that uses simplefx binding to track `@Bind` dependencies automatically.
 
 #### Improvements
 * Reworked `ContainerFilter` — now an abstract class subclassed directly (or built via `fromContainer` / `fromReactiveContainer` factories), with per-instance identity and a `WeakReference`-held wrapper so it can be garbage-collected once no live scene graph references it. The new `StatefulFilter` base it extends fails fast when any container/stateful filter is constructed inside a per-request lambda (`filterWhen` / `filterWhenFuture`). **Breaking**: removes `ContainerFactory`, `RouteUtils.SFXContainerFactory`, and the old `ContainerFilter.create(supplier, clazz)` factory.

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/filter/container/TestStyleClassFilter.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/filter/container/TestStyleClassFilter.scala
@@ -1,0 +1,98 @@
+package one.jpro.platform.routing.filter.container
+
+import javafx.collections.FXCollections
+import javafx.scene.Node
+import javafx.scene.control.Label
+import javafx.scene.layout.StackPane
+import one.jpro.platform.routing._
+import org.junit.jupiter.api.{BeforeAll, Test}
+import simplefx.all._
+import simplefx.core._
+import simplefx.experimental._
+
+import scala.concurrent.Await
+import scala.collection.JavaConverters._
+
+object TestStyleClassFilter {
+  @BeforeAll
+  def setup(): Unit = {
+    Await.result(simplefx.cores.initializeCore(), (second))
+  }
+}
+
+class TestStyleClassFilter {
+
+  private def runRequest(route: Route, req: Request): Node = {
+    val result = inFX(route.apply(req).future).await
+    result.asInstanceOf[View].realContent
+  }
+
+  @Test
+  def styleClassesAreAppliedToWrapper(): Unit = {
+    val filter = new StyleClassFilter("light", "background")
+    val route = Route.get("/", _ => Response.node(new Label())).filter(filter)
+    val container = runRequest(route, Request.fromString("http://localhost/")).asInstanceOf[StackPane]
+
+    assert(container.getStyleClass.asScala.toList.contains("light"))
+    assert(container.getStyleClass.asScala.toList.contains("background"))
+  }
+
+  @Test
+  def styleClassesReflectTheSourceObservableList(): Unit = {
+    val classes = FXCollections.observableArrayList("light")
+    val filter = new StyleClassFilter(classes)
+    val route = Route.get("/", _ => Response.node(new Label())).filter(filter)
+    val container = runRequest(route, Request.fromString("http://localhost/")).asInstanceOf[StackPane]
+
+    assert(container.getStyleClass.asScala.toList == List("light"))
+
+    inFX { classes.add("mobile") }
+    assert(container.getStyleClass.asScala.toList == List("light", "mobile"))
+
+    inFX { classes.remove("mobile") }
+    assert(container.getStyleClass.asScala.toList == List("light"))
+  }
+
+  /** Holder class so we can use a `@Bind var` from inside a test method. */
+  private class MobileToggle {
+    @Bind var isMobile: Boolean = false
+  }
+
+  @Test
+  def byNameOverloadTracksReactiveDependency(): Unit = {
+    val toggle = inFX { new MobileToggle }
+    val filter = inFX {
+      Filters.styleClasses(
+        if (toggle.isMobile) List("light", "mobile") else List("light"))
+    }
+    val route = Route.get("/", _ => Response.node(new Label())).filter(filter)
+    val container = runRequest(route, Request.fromString("http://localhost/")).asInstanceOf[StackPane]
+
+    assert(container.getStyleClass.asScala.toList == List("light"))
+
+    inFX { toggle.isMobile = true }
+    assert(container.getStyleClass.asScala.toList == List("light", "mobile"))
+
+    inFX { toggle.isMobile = false }
+    assert(container.getStyleClass.asScala.toList == List("light"))
+  }
+
+  @Test
+  def stackingStylesheetsAndStyleClasses(): Unit = {
+    val sheetsFilter = new StylesheetsFilter("/main.css")
+    val classesFilter = new StyleClassFilter("light")
+    val route =
+      Route.get("/", _ => Response.node(new Label("page")))
+        .filter(sheetsFilter)
+        .filter(classesFilter)
+
+    // The outer filter (last one in the chain) wraps the result, so the
+    // returned wrapper is the StyleClassFilter's container; its child is
+    // the StylesheetsFilter's container.
+    val outer = runRequest(route, Request.fromString("http://localhost/")).asInstanceOf[StackPane]
+    assert(outer.getStyleClass.asScala.toList.contains("light"))
+
+    val inner = outer.getChildren.get(0).asInstanceOf[StackPane]
+    assert(inner.getStylesheets.asScala.toList == List("/main.css"))
+  }
+}

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/filter/container/TestStylesheetsFilter.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/filter/container/TestStylesheetsFilter.scala
@@ -7,19 +7,21 @@ import javafx.scene.layout.StackPane
 import one.jpro.jmemorybuddy.JMemoryBuddy
 import one.jpro.platform.routing._
 import org.junit.jupiter.api.{BeforeAll, Test}
+import simplefx.all._
 import simplefx.core._
+import simplefx.experimental._
 
 import scala.concurrent.Await
 import scala.collection.JavaConverters._
 
-object TestCssFilter {
+object TestStylesheetsFilter {
   @BeforeAll
   def setup(): Unit = {
     Await.result(simplefx.cores.initializeCore(), (second))
   }
 }
 
-class TestCssFilter {
+class TestStylesheetsFilter {
 
   /** Run a route on the FX thread, await its future, return the wrapper Node. */
   private def runRequest(route: Route, req: Request): Node = {
@@ -31,7 +33,7 @@ class TestCssFilter {
 
   @Test
   def containerIsReusedAcrossRequests(): Unit = {
-    val filter = new CssFilter("/test.css")
+    val filter = new StylesheetsFilter("/test.css")
     val route =
       Route.empty()
         .and(Route.get("/a", _ => Response.node(new Label("A"))))
@@ -40,20 +42,18 @@ class TestCssFilter {
 
     val c1 = runRequest(route, Request.fromString("http://localhost/a"))
     assert(c1 != null, "first request should produce a wrapper Node")
-    assert(c1.isInstanceOf[StackPane], "CssFilter wraps in a StackPane")
+    assert(c1.isInstanceOf[StackPane], "StylesheetsFilter wraps in a StackPane")
 
-    // Feed c1 as oldContent for the next request.
     val c2 = runRequest(route, Request.fromString("http://localhost/b", c1))
-
     assert(c1 eq c2, "the wrapper Node should be reused across requests")
   }
 
   // ----- Identity isolation between two filter instances -----
 
   @Test
-  def twoCssFiltersHaveDistinctContainers(): Unit = {
-    val a = new CssFilter("/a.css")
-    val b = new CssFilter("/b.css")
+  def twoStylesheetsFiltersHaveDistinctContainers(): Unit = {
+    val a = new StylesheetsFilter("/a.css")
+    val b = new StylesheetsFilter("/b.css")
 
     val routeA = Route.get("/", _ => Response.node(new Label("a"))).filter(a)
     val routeB = Route.get("/", _ => Response.node(new Label("b"))).filter(b)
@@ -61,7 +61,6 @@ class TestCssFilter {
     val cA = runRequest(routeA, Request.fromString("http://localhost/"))
     assert(cA != null)
 
-    // Pass A's container as oldContent into B — B must NOT reuse it.
     val cB = runRequest(routeB, Request.fromString("http://localhost/", cA))
     assert(cB != null)
 
@@ -74,7 +73,7 @@ class TestCssFilter {
   def constructingStatefulFilterInsideFilterWhenFails(): Unit = {
     val route =
       Route.get("/", _ => Response.node(new Label()))
-        .filterWhen(_ => true, _ => new CssFilter("/x.css"))
+        .filterWhen(_ => true, _ => new StylesheetsFilter("/x.css"))
 
     var threw = false
     try {
@@ -82,12 +81,12 @@ class TestCssFilter {
     } catch {
       case _: IllegalStateException => threw = true
     }
-    assert(threw, "constructing CssFilter inside filterWhen should fail fast")
+    assert(threw, "constructing StylesheetsFilter inside filterWhen should fail fast")
   }
 
   @Test
   def hoistedStatefulFilterInsideFilterWhenIsFine(): Unit = {
-    val css = new CssFilter("/x.css")
+    val css = new StylesheetsFilter("/x.css")
     val route =
       Route.get("/", _ => Response.node(new Label()))
         .filterWhen(_ => true, _ => css)
@@ -98,43 +97,62 @@ class TestCssFilter {
 
   @Test
   def topLevelStatefulFilterConstructionIsFine(): Unit = {
-    val css = new CssFilter("/x.css")
+    val css = new StylesheetsFilter("/x.css")
     val route = Route.get("/", _ => Response.node(new Label())).filter(css)
     val c = runRequest(route, Request.fromString("http://localhost/"))
     assert(c != null)
   }
 
-  // ----- Reactive stylesheet binding -----
+  // ----- Reactive stylesheet binding (ObservableList) -----
 
   @Test
   def stylesheetsReflectTheSourceObservableList(): Unit = {
     val sheets = FXCollections.observableArrayList("/initial.css")
-    val css = new CssFilter(sheets)
+    val css = new StylesheetsFilter(sheets)
     val route = Route.get("/", _ => Response.node(new Label())).filter(css)
 
     val container = runRequest(route, Request.fromString("http://localhost/")).asInstanceOf[StackPane]
     assert(container != null)
     assert(container.getStylesheets.asScala.toList == List("/initial.css"))
 
-    // Mutate the source list — the container should pick it up.
-    inFX {
-      sheets.add("/extra.css")
-    }
+    inFX { sheets.add("/extra.css") }
     assert(container.getStylesheets.asScala.toList == List("/initial.css", "/extra.css"))
 
-    inFX {
-      sheets.remove("/initial.css")
-    }
+    inFX { sheets.remove("/initial.css") }
     assert(container.getStylesheets.asScala.toList == List("/extra.css"))
+  }
+
+  // ----- Scala by-name (simplefx) overload -----
+
+  /** Holder class so we can use a `@Bind var` from inside a test method. */
+  private class MobileToggle {
+    @Bind var isMobile: Boolean = false
+  }
+
+  @Test
+  def byNameOverloadTracksReactiveDependency(): Unit = {
+    val toggle = inFX { new MobileToggle }
+    val filter = inFX {
+      Filters.stylesheets(
+        if (toggle.isMobile) List("/mobile.css") else List("/desktop.css"))
+    }
+    val route = Route.get("/", _ => Response.node(new Label())).filter(filter)
+
+    val container = runRequest(route, Request.fromString("http://localhost/")).asInstanceOf[StackPane]
+    assert(container != null)
+    assert(container.getStylesheets.asScala.toList == List("/desktop.css"))
+
+    inFX { toggle.isMobile = true }
+    assert(container.getStylesheets.asScala.toList == List("/mobile.css"))
+
+    inFX { toggle.isMobile = false }
+    assert(container.getStylesheets.asScala.toList == List("/desktop.css"))
   }
 
   // ----- Memory: container is GC-collectible when no live scene holds it -----
 
-  /**
-   * A trivial ContainerFilter with no bindings or other side-state — used to
-   * isolate the WeakReference fix in `ContainerFilter` from any
-   * filter-specific reference leaks (e.g. listener pinning in `CssFilter`).
-   */
+  /** A trivial ContainerFilter with no bindings — isolates the WeakReference
+   *  fix in `ContainerFilter` from any filter-specific reference leaks. */
   private class TrivialContainerFilter extends ContainerFilter {
     override def createNode(): Node = new StackPane()
     override def setContent(c: Node, x: Node): Unit =
@@ -147,29 +165,21 @@ class TestCssFilter {
 
   @Test
   def trivialContainerIsCollectibleAfterStrongRefDropped(): Unit = {
-    // The filter is alive (held by `filter` here in the test). Without
-    // the WeakReference fix in ContainerFilter, the filter would hold the
-    // wrapper Node strongly via a private field, defeating GC. With the
-    // fix, only the in-test `container` local pins it; once that's marked
-    // collectable, JMemoryBuddy.memoryTest forces GC and asserts collection.
     val filter = new TrivialContainerFilter
     val route = Route.get("/", _ => Response.node(new Label("page"))).filter(filter)
 
     JMemoryBuddy.memoryTest { checker =>
       val container = runRequest(route, Request.fromString("http://localhost/"))
       assert(container != null)
-      checker.setAsReferenced(filter) // we still hold the filter, that's fine
+      checker.setAsReferenced(filter)
       checker.assertCollectable(container)
     }
   }
 
   @Test
-  def cssFilterContainerIsCollectibleAfterStrongRefDropped(): Unit = {
-    // Same test as above but with CssFilter — exercises the
-    // WeakListChangeListener path in CssFilter that prevents the source
-    // ObservableList from pinning the wrapper.
+  def stylesheetsFilterContainerIsCollectibleAfterStrongRefDropped(): Unit = {
     val sheets = FXCollections.observableArrayList("/test.css")
-    val filter = new CssFilter(sheets)
+    val filter = new StylesheetsFilter(sheets)
     val route = Route.get("/", _ => Response.node(new Label("page"))).filter(filter)
 
     JMemoryBuddy.memoryTest { checker =>

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Filters.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Filters.scala
@@ -2,32 +2,83 @@ package one.jpro.platform.routing
 
 import javafx.collections.{FXCollections, ObservableList}
 import javafx.scene.control.Label
-import one.jpro.platform.routing.filter.container.CssFilter
+import one.jpro.platform.routing.filter.container.{StyleClassFilter, StylesheetsFilter}
 import simplefx.all
+import simplefx.all._
+import simplefx.core._
+import simplefx.experimental._
+import scala.collection.JavaConverters._
 import java.util.function.Function
 import java.util.function.BiFunction
 
 object Filters {
 
+  // ----- Stylesheets -----
+
   /**
-   * Wraps the matched view in a `StackPane` whose stylesheets reflect the
-   * given list. Mutating the list at runtime updates the wrapper's
-   * stylesheets immediately, so this can be driven by an `isMobile`
-   * subscription, a theme switcher, etc.
+   * Wraps the matched view in a `StackPane` whose `getStylesheets()` reflects
+   * the given list. Mutating the list at runtime updates the wrapper's
+   * stylesheets immediately — drive it from an `isMobile` subscription, a
+   * theme switcher, etc.
    *
-   * Note: this returns a [[StatefulFilter]] (specifically a [[CssFilter]]).
-   * Each call creates a new instance with its own identity. As with any
-   * stateful filter, do NOT call this from inside a per-request lambda
-   * (`filterWhen`, `filterWhenFuture`) — hoist it to a field on your
+   * Returns a [[StatefulFilter]]; do NOT call this from inside a per-request
+   * lambda (`filterWhen`, `filterWhenFuture`) — hoist it to a field on your
    * RouteApp or a Site object instead.
    */
-  def css(sheets: ObservableList[String]): Filter = new CssFilter(sheets)
+  def stylesheets(sheets: ObservableList[String]): Filter = new StylesheetsFilter(sheets)
 
   /** Convenience overload for a fixed (non-reactive) list of stylesheets. */
-  def css(sheets: String*): Filter = new CssFilter(FXCollections.observableArrayList(sheets: _*))
+  def stylesheets(sheets: String*): Filter = new StylesheetsFilter(FXCollections.observableArrayList(sheets: _*))
 
-  /** Java-friendly varargs overload. */
-  def css(sheets: Array[String]): Filter = new CssFilter(FXCollections.observableArrayList(sheets: _*))
+  /** Java-friendly array overload. */
+  def stylesheets(sheets: Array[String]): Filter = new StylesheetsFilter(FXCollections.observableArrayList(sheets: _*))
+
+  /**
+   * Scala-only by-name overload using simplefx reactive binding. The
+   * `expression` is wrapped in a `Bindable`; whenever a `@Bind` value it
+   * reads changes, the wrapper's stylesheets are updated automatically.
+   *
+   * {{{
+   *   filter(Filters.stylesheets(
+   *     if (isMobile) List(MAIN_CSS, MOBILE_CSS)
+   *     else          List(MAIN_CSS, DESKTOP_CSS)))
+   * }}}
+   */
+  def stylesheets(expression: => List[String]): Filter = {
+    val list = FXCollections.observableArrayList[String]()
+    @Bind var listB = list.toBindable
+    listB <-- expression
+    new StylesheetsFilter(list)
+  }
+
+  // ----- Style classes -----
+
+  /**
+   * Wraps the matched view in a `StackPane` whose `getStyleClass()` reflects
+   * the given list. Same usage and lifecycle constraints as
+   * [[stylesheets]] — see its docs.
+   *
+   * Stack with [[stylesheets]] when you want both: each is its own filter
+   * and produces its own wrapper container.
+   */
+  def styleClasses(classes: ObservableList[String]): Filter = new StyleClassFilter(classes)
+
+  /** Convenience overload for a fixed (non-reactive) list of style classes. */
+  def styleClasses(classes: String*): Filter = new StyleClassFilter(FXCollections.observableArrayList(classes: _*))
+
+  /** Java-friendly array overload. */
+  def styleClasses(classes: Array[String]): Filter = new StyleClassFilter(FXCollections.observableArrayList(classes: _*))
+
+  /**
+   * Scala-only by-name overload using simplefx reactive binding. Mirror of
+   * [[stylesheets(expression:=>List[String])*]] but for style classes.
+   */
+  def styleClasses(expression: => List[String]): Filter = {
+    val list = FXCollections.observableArrayList[String]()
+    @Bind var listB = list.toBindable
+    listB <-- expression
+    new StyleClassFilter(list)
+  }
 
   def FullscreenFilter(fullscreenValue: Boolean): Filter = { route => { request =>
       val r = route.apply(request)

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/StyleClassFilter.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/StyleClassFilter.scala
@@ -1,0 +1,47 @@
+package one.jpro.platform.routing.filter.container
+
+import javafx.collections.{FXCollections, ListChangeListener, ObservableList, WeakListChangeListener}
+import javafx.scene.Node
+import javafx.scene.layout.StackPane
+
+/**
+ * A [[ContainerFilter]] that wraps the matched view in a `StackPane` whose
+ * `getStyleClass()` mirrors a caller-supplied `ObservableList[String]`.
+ *
+ * The mirror image of [[StylesheetsFilter]] but for style classes instead of
+ * stylesheet URLs. CSS rules using these classes (e.g. `.light .h1`) match
+ * descendants of the wrapper because JavaFX selector evaluation walks
+ * ancestors regardless of which Parent owns the stylesheet.
+ *
+ * Compose with [[StylesheetsFilter]] when you want both — they stack as
+ * siblings in the route filter chain.
+ */
+class StyleClassFilter(classes: ObservableList[String]) extends ContainerFilter {
+
+  /** Convenience constructor for fixed (non-reactive) style class lists. */
+  def this(classes: String*) = this(FXCollections.observableArrayList(classes: _*))
+
+  override def createNode(): Node = new StyleClassContainer(classes)
+
+  override def setContent(container: Node, content: Node): Unit = {
+    val stack = container.asInstanceOf[StackPane]
+    stack.getChildren.setAll(content)
+  }
+
+  override def getContent(container: Node): Node = {
+    val children = container.asInstanceOf[StackPane].getChildren
+    if (children.isEmpty) null else children.get(0)
+  }
+}
+
+/** Internal wrapper Node for [[StyleClassFilter]]. Same GC pattern as
+ *  [[StylesheetsFilter]] — strong listener field on the container, observed
+ *  via `WeakListChangeListener` so the source list doesn't pin the wrapper. */
+private final class StyleClassContainer(source: ObservableList[String]) extends StackPane {
+  getStyleClass.setAll(source)
+
+  private val sourceListener: ListChangeListener[String] =
+    (_: ListChangeListener.Change[_ <: String]) => getStyleClass.setAll(source)
+
+  source.addListener(new WeakListChangeListener[String](sourceListener))
+}

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/StylesheetsFilter.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/StylesheetsFilter.scala
@@ -11,12 +11,12 @@ import javafx.scene.layout.StackPane
  * one sub-route subtree cannot bleed into siblings. Mutating the source list
  * at runtime — desktop/mobile swap, theme switch — propagates immediately.
  */
-class CssFilter(sheets: ObservableList[String]) extends ContainerFilter {
+class StylesheetsFilter(sheets: ObservableList[String]) extends ContainerFilter {
 
   /** Convenience constructor for fixed (non-reactive) stylesheet lists. */
   def this(sheets: String*) = this(FXCollections.observableArrayList(sheets: _*))
 
-  override def createNode(): Node = new CssFilterContainer(sheets)
+  override def createNode(): Node = new StylesheetsFilterContainer(sheets)
 
   override def setContent(container: Node, content: Node): Unit = {
     val stack = container.asInstanceOf[StackPane]
@@ -29,10 +29,10 @@ class CssFilter(sheets: ObservableList[String]) extends ContainerFilter {
   }
 }
 
-/** Internal wrapper Node for [[CssFilter]]. The strong listener field lives
+/** Internal wrapper Node for [[StylesheetsFilter]]. The strong listener field lives
  *  on the container; the source observes it via `WeakListChangeListener`, so
  *  the source list does not pin the container in memory. */
-private final class CssFilterContainer(source: ObservableList[String]) extends StackPane {
+private final class StylesheetsFilterContainer(source: ObservableList[String]) extends StackPane {
   getStylesheets.setAll(source)
 
   private val sourceListener: ListChangeListener[String] =


### PR DESCRIPTION
Splits the CSS scoping into two orthogonal filters: `Filters.stylesheets(...)` (renamed from `Filters.css`) for stylesheets, and the new `Filters.styleClasses(...)` for style classes. Both have a Scala-only by-name overload (`=> List[String]`) that uses simplefx binding so reactive expressions track `@Bind` dependencies automatically. Follow-up to #95.