### PR TITLE
Remove unnecessary `javafx.fxml` requirement from jpro-mdfx

### DIFF
--- a/jpro-mdfx/src/main/java/module-info.java
+++ b/jpro-mdfx/src/main/java/module-info.java
@@ -1,6 +1,5 @@
 module one.jpro.platform.mdfx {
     requires javafx.controls;
-    requires javafx.fxml;
     requires flexmark;
     requires flexmark.ext.attributes;
     requires flexmark.ext.tables;


### PR DESCRIPTION
This PR removes the `javafx.fxml` module requirement from `jpro-mdfx`.

`jpro-mdfx` does not use FXML APIs, but declaring `javafx.fxml` as a required module forces downstream applications to add it whenever they depend on jpro-mdfx. 