### PR TITLE
Add optional copy button to mdfx code blocks

### DIFF
--- a/jpro-mdfx/README.md
+++ b/jpro-mdfx/README.md
@@ -112,6 +112,25 @@ Code blocks wrap their content by default. For source code where wrapping makes 
 
 When enabled, fenced code blocks keep their original horizontal layout and show a horizontal scrollbar when the code is wider than the available Markdown view width.
 
+### Copy Button
+
+Add a copy-to-clipboard button to the top-right corner of every code block:
+
+```css
+.markdown-code-block {
+    -mdfx-add-copy-button: true;
+}
+```
+
+Style it via the `.code-copy-button` class:
+
+```css
+.markdown-code-block .code-copy-button {
+    -fx-font-size: 0.8em;
+    -fx-background-radius: 6px;
+}
+```
+
 ## Supported Markdown Features
 
 Headings (H1–H5), bold, italic, strikethrough, links, images, ordered/unordered lists, task lists, fenced code blocks with syntax highlighting, inline code, GFM tables, blockquotes, attributes.

--- a/jpro-mdfx/build.gradle
+++ b/jpro-mdfx/build.gradle
@@ -13,6 +13,7 @@ javafx {
 
 dependencies {
     implementation project(':jpro-youtube')
+    implementation project(':jpro-utils')
     implementation "com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:$FLEXMARK_VERSION"
     implementation "com.vladsch.flexmark:flexmark-ext-gfm-tasklist:$FLEXMARK_VERSION"
     implementation "com.vladsch.flexmark:flexmark-ext-tables:$FLEXMARK_VERSION"

--- a/jpro-mdfx/example/src/main/java/one/jpro/platform/mdfx/example/MarkdownViewSample.java
+++ b/jpro-mdfx/example/src/main/java/one/jpro/platform/mdfx/example/MarkdownViewSample.java
@@ -65,6 +65,8 @@ public class MarkdownViewSample extends Application {
 
             .markdown-code-block {
                 -mdfx-code-theme: "/one/jpro/platform/mdfx/themes/github-light-default.json";
+                -mdfx-scrollable: true;
+                -mdfx-add-copy-button: true;
             }
             */
             """;
@@ -85,6 +87,7 @@ public class MarkdownViewSample extends Application {
             }
             .markdown-code-block {
                 -mdfx-code-theme: "/one/jpro/platform/mdfx/themes/github-dark-default.json";
+                -mdfx-add-copy-button: true;
             }
             """;
 
@@ -150,6 +153,7 @@ public class MarkdownViewSample extends Application {
         Scene scene = new Scene(createRoot(stage), 1200, 700);
         stage.setScene(scene);
         stage.show();
+        //ScenicView.show(scene);
     }
 
     public Parent createRoot(Stage stage) {

--- a/jpro-mdfx/src/main/java/module-info.java
+++ b/jpro-mdfx/src/main/java/module-info.java
@@ -13,6 +13,7 @@ module one.jpro.platform.mdfx {
     requires flexmark.util.data;
     requires flexmark.util.collection;
     requires static one.jpro.platform.youtube;
+    requires one.jpro.platform.utils;
     requires tm4javafx;
     requires tm4java;
     requires jfx.incubator.richtext;

--- a/jpro-mdfx/src/main/java/one/jpro/platform/mdfx/MarkdownCodeBlock.java
+++ b/jpro-mdfx/src/main/java/one/jpro/platform/mdfx/MarkdownCodeBlock.java
@@ -2,11 +2,15 @@ package one.jpro.platform.mdfx;
 
 import javafx.css.*;
 import javafx.beans.property.BooleanProperty;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
+import one.jpro.platform.utils.CopyUtil;
 import tm4javafx.richtext.StyleHelper;
 import tm4javafx.richtext.StyleProvider;
 import tm4javafx.richtext.TextFlowModel;
@@ -28,6 +32,7 @@ public class MarkdownCodeBlock extends StackPane {
 
     private static final String DEFAULT_STYLE_CLASS = "markdown-code-block";
     private static final String SCROLLABLE_STYLE_CLASS = "scrollable";
+    private static final String COPY_BUTTON_STYLE_CLASS = "code-copy-button";
     private static final String DEFAULT_CODE_THEME = "/one/jpro/platform/mdfx/themes/github-light-default.json";
 
     private static final Map<String, String> LANGUAGE_TO_GRAMMAR = new HashMap<>();
@@ -100,19 +105,35 @@ public class MarkdownCodeBlock extends StackPane {
                 }
             };
 
+    private static final CssMetaData<MarkdownCodeBlock, Boolean> ADD_COPY_BUTTON =
+            new CssMetaData<>("-mdfx-add-copy-button", StyleConverter.getBooleanConverter(), false) {
+                @Override
+                public boolean isSettable(MarkdownCodeBlock node) {
+                    return !node.addCopyButton.isBound();
+                }
+
+                @Override
+                public StyleableProperty<Boolean> getStyleableProperty(MarkdownCodeBlock node) {
+                    return node.addCopyButton;
+                }
+            };
+
     private static final List<CssMetaData<? extends Styleable, ?>> STYLEABLES;
     static {
         List<CssMetaData<? extends Styleable, ?>> list = new ArrayList<>(StackPane.getClassCssMetaData());
         list.add(CODE_THEME);
         list.add(SCROLLABLE);
+        list.add(ADD_COPY_BUTTON);
         STYLEABLES = Collections.unmodifiableList(list);
     }
 
     private final StyleableStringProperty codeTheme = new SimpleStyleableStringProperty(CODE_THEME, this, "codeTheme", DEFAULT_CODE_THEME);
     private final StyleableBooleanProperty scrollable = new SimpleStyleableBooleanProperty(SCROLLABLE, this, "scrollable", false);
+    private final StyleableBooleanProperty addCopyButton = new SimpleStyleableBooleanProperty(ADD_COPY_BUTTON, this, "addCopyButton", false);
 
     private final TextFlow textFlow;
     private final ScrollPane scrollPane;
+    private Button copyButton;
     private final String code;
     private final String language;
     private final Class<?> resourceBaseClass;
@@ -144,6 +165,7 @@ public class MarkdownCodeBlock extends StackPane {
         updateScrollableState();
 
         scrollable.subscribe(v -> updateScrollableState());
+        addCopyButton.subscribe(v -> updateScrollableState());
         codeTheme.subscribe(v -> updateContent());
     }
 
@@ -159,6 +181,18 @@ public class MarkdownCodeBlock extends StackPane {
         return scrollable;
     }
 
+    public final boolean isAddCopyButton() {
+        return addCopyButton.get();
+    }
+
+    public final void setAddCopyButton(boolean addCopyButton) {
+        this.addCopyButton.set(addCopyButton);
+    }
+
+    public final BooleanProperty addCopyButtonProperty() {
+        return addCopyButton;
+    }
+
     private void updateScrollableState() {
         getStyleClass().remove(SCROLLABLE_STYLE_CLASS);
         getChildren().clear();
@@ -172,7 +206,23 @@ public class MarkdownCodeBlock extends StackPane {
             getChildren().add(textFlow);
         }
 
+        if (isAddCopyButton()) {
+            getChildren().add(getOrCreateCopyButton());
+        }
+
         updateTextFlowMinWidth();
+    }
+
+    private Button getOrCreateCopyButton() {
+        if (copyButton == null) {
+            copyButton = new Button("Copy");
+            copyButton.getStyleClass().add(COPY_BUTTON_STYLE_CLASS);
+            copyButton.setFocusTraversable(false);
+            CopyUtil.setCopyOnClick(copyButton, code == null ? "" : code);
+            StackPane.setAlignment(copyButton, Pos.TOP_RIGHT);
+            StackPane.setMargin(copyButton, new Insets(8));
+        }
+        return copyButton;
     }
 
     private void updateTextFlowMinWidth() {

--- a/jpro-mdfx/src/main/resources/one/jpro/platform/mdfx/mdfx.css
+++ b/jpro-mdfx/src/main/resources/one/jpro/platform/mdfx/mdfx.css
@@ -215,3 +215,15 @@
     -fx-border-radius: 8px;
     -fx-background-radius: 8px;
 }
+
+.markdown-code-block .code-copy-button {
+    -fx-padding: 2px 8px;
+    -fx-font-size: 0.85em;
+    -fx-background-radius: 6px;
+    -fx-cursor: hand;
+    -fx-opacity: 0.65;
+}
+
+.markdown-code-block:hover .code-copy-button {
+    -fx-opacity: 1.0;
+}


### PR DESCRIPTION
## Summary
- New CSS-styleable boolean property `-mdfx-add-copy-button` on `MarkdownCodeBlock` adds a copy-to-clipboard button at the top-right of the code block.
- Uses `CopyUtil` so it works on desktop and in JPro (browser).
- Default styling kept minimal (native button look); README has a small example for customizing via `.code-copy-button`.

## Test plan
- [x] `./gradlew :jpro-mdfx:compileJava :jpro-mdfx:test`
- [ ] Run `MarkdownViewSample` on desktop, toggle Dark style, click copy on a code block, paste elsewhere
- [ ] Run sample in JPro, verify copy via `navigator.clipboard`