### PR TITLE
Rename routing View to Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * `jpro-routing`: Documented Pages, filters, containers, popups and dev tools in the README.
 
 #### Breaking
-* `jpro-routing`: Renamed `View` to `Page` (the historic name never matched the routing/web vocabulary). This renames the class and its API surface — `Response.page(...)` (was `Response.view`), `SessionManager.getPage()` (was `getView`), `Page.fromNode(...)`, `subPage()`, `NodePage` — with no compatibility alias. Migration is a mechanical rename in user code.
+* `jpro-routing`: Renamed `View` to `Page`. Affects `Response.page(...)` (was `Response.view`), `SessionManager.getPage()` (was `getView`), `Page.fromNode(...)`, `subPage()`, and `NodePage`.
 
 ### 0.6.3 (May 25, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 0.6.4 (unreleased)
+
+#### Improvements
+* `jpro-routing`: Documented Pages, filters, containers, popups and dev tools in the README.
+
+#### Breaking
+* `jpro-routing`: Renamed `View` to `Page` (the historic name never matched the routing/web vocabulary). This renames the class and its API surface — `Response.page(...)` (was `Response.view`), `SessionManager.getPage()` (was `getView`), `Page.fromNode(...)`, `subPage()`, `NodePage` — with no compatibility alias. Migration is a mechanical rename in user code.
+
 ### 0.6.3 (May 25, 2026)
 
 #### Features

--- a/jpro-routing/README.md
+++ b/jpro-routing/README.md
@@ -101,7 +101,7 @@ Response static methods:
 ```
 Response.empty()
 Response.node(Node node)
-Response.view(View view)
+Response.page(Page page)
 Response.redirect(String to)
 Response.error(Exception ex)
 Response.fromFuture(FXFuture<Response> future)
@@ -164,7 +164,7 @@ If it's scrollable, the content is never cut off - but you usually get a scrollb
 On the browser, scrollable uses the native scrolling of the browser.
 
 This can be configured with the following methods
-1. Override the method `View.fullscreen()` in your View
+1. Override the method `Page.fullscreen()` in your Page
 2. Use the filter `Filters.FullscreenFilter(boolean)` to set it for a Route
 
 
@@ -178,25 +178,25 @@ checkout our sample project: https://github.com/JPro-one/jpro-routing-sample
 
 
 
-### Views
+### Pages
 
-`Response.node(...)` is the quickest way to show something — but wrapping content in a `View`
-gives a page its metadata and lifecycle:
+`Response.node(...)` is the quickest way to show something — but wrapping content in a `Page`
+gives it metadata and lifecycle:
 
 ```java
-public class HomePage extends View {
+public class HomePage extends Page {
     @Override public String title() { return "Home"; }
     @Override public String description() { return "The landing page of this application."; }
     @Override public Node content() { return new Label("Welcome!"); }
 }
 // in the route:
-Route.get("/", r -> Response.view(new HomePage()))
+Route.get("/", r -> Response.page(new HomePage()))
 ```
 
 - `title` and `description` are used for the browser tab and for SEO (and by the AppCrawler, see below)
 - `fullscreen()` — override to control fullscreen vs scrollable per page
 - `onClose()` — called when the user navigates away from the page
-- `handleRequest(Request)` — return true to handle URL changes inside the view yourself
+- `handleRequest(Request)` — return true to handle URL changes inside the page yourself
   (e.g. for tab navigation within one page, without recreating it)
 
 ### Built-in Filters

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestAppCrawler.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestAppCrawler.scala
@@ -5,7 +5,7 @@ import simplefx.core._
 import TestUtils._
 import javafx.application.Platform
 import one.jpro.platform.routing.crawl.AppCrawler.LinkInfo
-import one.jpro.platform.routing.{LinkUtil, Response, Route, RouteNode, RouteUtils, View}
+import one.jpro.platform.routing.{LinkUtil, Response, Route, RouteNode, RouteUtils, Page}
 import simplefx.all
 import org.junit.jupiter.api.{BeforeAll, Test}
 import simplefx.util.Predef.intercept
@@ -43,8 +43,8 @@ class TestAppCrawler {
   @Test
   def testCrawlApp(): Unit = {
     def route = Route.empty()
-        .and(Route.get("/", r => Response.view(new Page1)))
-        .and(Route.get("/page2", r => Response.view(new Page2)))
+        .and(Route.get("/", r => Response.page(new Page1)))
+        .and(Route.get("/page2", r => Response.page(new Page2)))
     val result = AppCrawler.crawlRoute("http://localhost", () => route)
 
     assert(result.pages.contains("/"), result.pages)
@@ -56,7 +56,7 @@ class TestAppCrawler {
   @Test
   def testEmptyImage(): Unit = {
     def route = Route.empty()
-        .and(Route.get("/", r => Response.view(new View {
+        .and(Route.get("/", r => Response.page(new Page {
           override def title: String = ""
 
           override def description: String = ""
@@ -68,7 +68,7 @@ class TestAppCrawler {
 
   @Test
   def testIndexListview(): Unit = inFX{
-    val view = new View {
+    val page = new Page {
       override def title: String = ""
       override def description: String = ""
       val content: all.Node = new ListView[String] {
@@ -83,14 +83,14 @@ class TestAppCrawler {
         cellFactory = (v: ListView[String]) => new MyListCell
       }
     }
-    val r = AppCrawler.crawlPage(view)
+    val r = AppCrawler.crawlPage(page)
     assert(r.links.contains(LinkInfo("/list1","")))
     assert(r.links.contains(LinkInfo("/list9","")))
   }
 
   @Test
   def testScrollPane(): Unit = inFX{
-    val view = new View {
+    val page = new Page {
       override def title: String = ""
       override def description: String = ""
       val content: all.Node = new ScrollPane {
@@ -99,13 +99,13 @@ class TestAppCrawler {
         }
       }
     }
-    val r = AppCrawler.crawlPage(view)
+    val r = AppCrawler.crawlPage(page)
     assert(r.links.contains(LinkInfo("/scrollpane","")))
   }
 
   @Test
   def testImageInStyle (): Unit = {
-    def view = new View {
+    def page = new Page {
       override def title: String = ""
       override def description: String = ""
       val content: Node = new Region() {
@@ -113,7 +113,7 @@ class TestAppCrawler {
       }
     }
     val r = AppCrawler.crawlRoute("http://localhost", () =>
-      Route.empty().and(Route.get("/", r => Response.view(view)))
+      Route.empty().and(Route.get("/", r => Response.page(page)))
     )
     assert(r.pages.size() == 1)
     assert(!r.reports.get(0).pictures.isEmpty)
@@ -121,7 +121,7 @@ class TestAppCrawler {
 
   @Test
   def testAccessingSessionManager (): Unit = inFX {
-    val view = new View {
+    val page = new Page {
       override def title: String = ""
       override def description: String = ""
       val content: Node = new Region() {
@@ -132,7 +132,7 @@ class TestAppCrawler {
         })
       }
     }
-    val r = AppCrawler.crawlPage(view)
+    val r = AppCrawler.crawlPage(page)
   }
 
 }

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestMemoryTester.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestMemoryTester.scala
@@ -19,9 +19,9 @@ class TestMemoryTester {
   @Test
   def simpleTest(): Unit = {
     def route = Route.empty()
-        .and(Route.get("/", r => Response.view(new Page1)))
-        .and(Route.get("/page2", r => Response.view(new Page2)))
-        .and(Route.get("/page4", r => Response.view(new Page2)))
+        .and(Route.get("/", r => Response.page(new Page1)))
+        .and(Route.get("/page2", r => Response.page(new Page2)))
+        .and(Route.get("/page4", r => Response.page(new Page2)))
     val result = AppCrawler.crawlRoute("http://localhost", () => route)
     MemoryTester.testForLeaks(result, () => route)
   }
@@ -30,9 +30,9 @@ class TestMemoryTester {
   def simpleFailingTest(): Unit = {
     val page2 = new Page2
     def route = Route.empty()
-        .and(Route.get("/", r => Response.view(new Page1)))
-        .and(Route.get("/page2", r => Response.view(page2)))
-        .and(Route.get("/page4", r => Response.view(new Page2)))
+        .and(Route.get("/", r => Response.page(new Page1)))
+        .and(Route.get("/page2", r => Response.page(page2)))
+        .and(Route.get("/page4", r => Response.page(new Page2)))
     val result = AppCrawler.crawlRoute("http://localhost", () => route)
     intercept[Throwable](MemoryTester.testForLeaks(result, () => route))
   }
@@ -42,9 +42,9 @@ class TestMemoryTester {
     var node2 = new Label()
 
     def route = Route.empty()
-        .and(Route.get("/", r => Response.view(new Page1)))
+        .and(Route.get("/", r => Response.page(new Page1)))
         .and(Route.get("/page2", r => Response.node(node2)))
-        .and(Route.get("/page4", r => Response.view(new Page2)))
+        .and(Route.get("/page4", r => Response.page(new Page2)))
 
     val result = AppCrawler.crawlRoute("http://localhost", () => route)
     intercept[Throwable](MemoryTester.testForLeaks(result, () => route))
@@ -55,9 +55,9 @@ class TestMemoryTester {
   def simpleFailingTest3(): Unit = {
 
     val route: Route = Route.empty()
-      .and(Route.get("/", r => Response.view(new Page1)))
+      .and(Route.get("/", r => Response.page(new Page1)))
       .and(Route.get("/page2", r => Response.node(new LeakStage)))
-      .and(Route.get("/page4", r => Response.view(new Page2)))
+      .and(Route.get("/page4", r => Response.page(new Page2)))
     val result = AppCrawler.crawlRoute("http://localhost", () => route)
     intercept[Throwable](MemoryTester.testForLeaks(result, () => route)) // fails because the webapp is not collectable
   }

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestSitemapGenerator.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestSitemapGenerator.scala
@@ -10,10 +10,10 @@ class TestSitemapGenerator {
   @Test
   def test(): Unit = {
     def route = Route.empty()
-        .and(get("/", r => Response.view(new Page1)))
-        .and(get("/page2", r => Response.view(new Page2)))
-        .and(get("/page4", r => Response.view(new Page2)))
-        .and(r => Response.view(new Page1))
+        .and(get("/", r => Response.page(new Page1)))
+        .and(get("/page2", r => Response.page(new Page2)))
+        .and(get("/page4", r => Response.page(new Page2)))
+        .and(r => Response.page(new Page1))
     val result = AppCrawler.crawlRoute("http://localhost", () => route)
     val sm = SitemapGenerator.createSitemap("http://localhost", result)
     println("Crawl Report: " + result)
@@ -27,7 +27,7 @@ class TestSitemapGenerator {
   @Test
   def testMailToRedirect(): Unit = {
     def route = Route.empty()
-      .and(get("/", r => Response.view(pageWithLink(List("/page2", "/page3", "mailto:something")))))
+      .and(get("/", r => Response.page(pageWithLink(List("/page2", "/page3", "mailto:something")))))
       .and(get("/page2", r => Response.redirect("mailto:something-2")))
     val result = AppCrawler.crawlRoute("http://localhost", () => route)
     println("got result: " + result)

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestSitemapGenerator.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestSitemapGenerator.scala
@@ -3,9 +3,20 @@ package one.jpro.platform.routing.crawl
 import one.jpro.platform.routing.Route._
 import one.jpro.platform.routing.crawl.TestUtils._
 import one.jpro.platform.routing.{Redirect, Response, Route, RouteNode}
-import org.junit.jupiter.api.Test
+import javafx.application.Platform
+import org.junit.jupiter.api.{BeforeAll, Test}
+import simplefx.all._
+import simplefx.core._
 import simplefx.experimental._
 
+object TestSitemapGenerator {
+  // Initialize the SimpleFX core on the FX thread; without this, running this
+  // class before any FX-initializing test poisons simplefx core for the whole suite
+  @BeforeAll
+  def init(): Unit = inFX {
+    Platform.setImplicitExit(false)
+  }
+}
 class TestSitemapGenerator {
   @Test
   def test(): Unit = {

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestUtils.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/crawl/TestUtils.scala
@@ -1,12 +1,12 @@
 package one.jpro.platform.routing.crawl
 
-import one.jpro.platform.routing.{LinkUtil, View}
+import one.jpro.platform.routing.{LinkUtil, Page}
 import simplefx.all._
 import simplefx.core._
 
 object TestUtils {
 
-  def pageWithLink(links: List[String]): View = new View {
+  def pageWithLink(links: List[String]): Page = new Page {
     def title = "title"
     def description = "desc"
     override def content: Node = new HBox {
@@ -18,7 +18,7 @@ object TestUtils {
     }
   }
 
-  class Page1 extends View {
+  class Page1 extends Page {
     def title = "title"
     def description = "desc"
 
@@ -39,7 +39,7 @@ object TestUtils {
     }
   }
 
-  class Page2 extends View {
+  class Page2 extends Page {
     def title = "title"
     def description = "desc"
 

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/filter/container/TestStyleClassFilter.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/filter/container/TestStyleClassFilter.scala
@@ -24,7 +24,7 @@ class TestStyleClassFilter {
 
   private def runRequest(route: Route, req: Request): Node = {
     val result = inFX(route.apply(req).future).await
-    result.asInstanceOf[View].realContent
+    result.asInstanceOf[Page].realContent
   }
 
   @Test

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/filter/container/TestStylesheetsFilter.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/filter/container/TestStylesheetsFilter.scala
@@ -26,7 +26,7 @@ class TestStylesheetsFilter {
   /** Run a route on the FX thread, await its future, return the wrapper Node. */
   private def runRequest(route: Route, req: Request): Node = {
     val result = inFX(route.apply(req).future).await
-    result.asInstanceOf[View].realContent
+    result.asInstanceOf[Page].realContent
   }
 
   // ----- Container reuse -----

--- a/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/sessionmanager/TestSessionManager.scala
+++ b/jpro-routing/core-test/src/test/scala/one/jpro/platform/routing/sessionmanager/TestSessionManager.scala
@@ -80,14 +80,14 @@ class TestSessionManager {
 
     val res1 = inFX(app.getSessionManager().gotoURL("/error").future).await
     inFX {
-      val view = app.getSessionManager().view
-      assert(view.realContent.asInstanceOf[Label].getText.contains("Error"), view.realContent.asInstanceOf[Label].getText)
+      val page = app.getSessionManager().page
+      assert(page.realContent.asInstanceOf[Label].getText.contains("Error"), page.realContent.asInstanceOf[Label].getText)
     }
 
     val res2 = inFX(app.getSessionManager().gotoURL("/error2").future).await
     inFX {
-      val view = app.getSessionManager().view
-      assert(view.realContent.asInstanceOf[Label].getText.contains("Error2"), view.realContent.asInstanceOf[Label].getText)
+      val page = app.getSessionManager().page
+      assert(page.realContent.asInstanceOf[Label].getText.contains("Error2"), page.realContent.asInstanceOf[Label].getText)
     }
   }
 
@@ -108,9 +108,9 @@ class TestSessionManager {
 
     val res = inFX(app.getSessionManager().gotoURL("/notfound").future).await
     inFX {
-      val view = app.getSessionManager().view
-      assert(view.realContent.asInstanceOf[Label].getText.contains("Not Found"), view.realContent.asInstanceOf[Label].getText)
-      println("Label Text: " + view.realContent.asInstanceOf[Label].getText)
+      val page = app.getSessionManager().page
+      assert(page.realContent.asInstanceOf[Label].getText.contains("Not Found"), page.realContent.asInstanceOf[Label].getText)
+      println("Label Text: " + page.realContent.asInstanceOf[Label].getText)
     }
   }*/
 

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Filters.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Filters.scala
@@ -16,7 +16,7 @@ object Filters {
   // ----- Stylesheets -----
 
   /**
-   * Wraps the matched view in a `StackPane` whose `getStylesheets()` reflects
+   * Wraps the matched page in a `StackPane` whose `getStylesheets()` reflects
    * the given list. Mutating the list at runtime updates the wrapper's
    * stylesheets immediately — drive it from an `isMobile` subscription, a
    * theme switcher, etc.
@@ -54,7 +54,7 @@ object Filters {
   // ----- Style classes -----
 
   /**
-   * Wraps the matched view in a `StackPane` whose `getStyleClass()` reflects
+   * Wraps the matched page in a `StackPane` whose `getStyleClass()` reflects
    * the given list. Same usage and lifecycle constraints as
    * [[stylesheets]] — see its docs.
    *
@@ -84,8 +84,8 @@ object Filters {
       val r = route.apply(request)
 
       Response(r.future.map {
-        case x: View =>
-          new View {
+        case x: Page =>
+          new Page {
             override def title: String = x.title
             override def description: String = x.description
             override def content: all.Node = x.realContent
@@ -101,8 +101,8 @@ object Filters {
       val _title = title
 
       Response(r.future.map {
-        case x: View =>
-          new View {
+        case x: Page =>
+          new Page {
             override def title: String = _title
             override def description: String = x.description
             override def content: all.Node = x.realContent
@@ -118,8 +118,8 @@ object Filters {
       val _description = description
 
       Response(r.future.map {
-        case x: View =>
-          new View {
+        case x: Page =>
+          new Page {
             override def title: String = x.title
             override def description: String = _description
             override def content: all.Node = x.realContent
@@ -136,8 +136,8 @@ object Filters {
       val _description = description
 
       Response(r.future.map {
-        case x: View =>
-          new View {
+        case x: Page =>
+          new Page {
             override def title: String = _title
             override def description: String = _description
             override def content: all.Node = x.realContent

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/LinkUtil.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/LinkUtil.scala
@@ -269,7 +269,7 @@ object LinkUtil {
     }
   }
 
-  def setImageViewDescription(view: ImageView, description: String): Unit = {
-    view.setAccessibleRoleDescription(description)
+  def setImageViewDescription(page: ImageView, description: String): Unit = {
+    page.setAccessibleRoleDescription(description)
   }
 }

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/NodePage.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/NodePage.scala
@@ -1,0 +1,7 @@
+package one.jpro.platform.routing
+
+import simplefx.all._
+
+trait NodePage extends Page { this: Node =>
+  final override def content: NodePage with Node = this
+}

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/NodeView.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/NodeView.scala
@@ -1,7 +1,0 @@
-package one.jpro.platform.routing
-
-import simplefx.all._
-
-trait NodeView extends View { this: Node =>
-  final override def content: NodeView with Node = this
-}

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Page.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Page.scala
@@ -4,10 +4,10 @@ import one.jpro.platform.routing.sessionmanager.SessionManager
 import simplefx.all
 import simplefx.all._
 
-object View {
-  def fromNode(node: javafx.scene.Node): View = RouteUtils.viewFromNode(node)
+object Page {
+  def fromNode(node: javafx.scene.Node): Page = RouteUtils.pageFromNode(node)
 }
-abstract class View extends ResponseResult { THIS =>
+abstract class Page extends ResponseResult { THIS =>
   def title: String
   def description: String
   var url: String = null
@@ -24,17 +24,17 @@ abstract class View extends ResponseResult { THIS =>
   def saveScrollPosition = true
   def fullscreen = false
   def onClose(): Unit = {}
-  def subView(): View = null
+  def subPage(): Page = null
 
-  override def toString: String = s"View(title: $title, url: $url, description: $description)"
+  override def toString: String = s"Page(title: $title, url: $url, description: $description)"
 
   /**
    * Only overwrite this method, if you handle the url-change by yourself.
    * @param x path
-   * @return whether the view handles the url change
+   * @return whether the page handles the url change
    */
   def handleRequest(x: Request): Boolean = false
-  def mapContent(f: Node => Node): View = new View {
+  def mapContent(f: Node => Node): Page = new Page {
     override def title: String = THIS.title
 
     override def description: String = THIS.description
@@ -48,7 +48,7 @@ abstract class View extends ResponseResult { THIS =>
       THIS.setSessionManager(x)
     }
 
-    override def subView(): View = THIS
+    override def subPage(): Page = THIS
   }
 }
 

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Response.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Response.scala
@@ -4,7 +4,7 @@ import simplefx.experimental.FXFuture
 
 /**
  * The result of applying a Route to a Request. A response wraps a future
- * ResponseResult — a view, a redirect, or null for "no match" (empty).
+ * ResponseResult — a page, a redirect, or null for "no match" (empty).
  */
 case class Response(future: FXFuture[ResponseResult]) {
   assert(future != null, "future must not be null - but it's value can be null")
@@ -21,14 +21,14 @@ object Response {
   /** Returns a response that completes with the given error. */
   def error(ex: Exception): Response = Response(FXFuture.error(ex))
 
-  /** Returns a response showing the given view. */
-  def view(view: View): Response = Response(FXFuture.unit(view))
-  /** Returns a response showing the given node, wrapped in a View. */
-  def node(node: javafx.scene.Node): Response = Response(FXFuture.unit(View.fromNode(node)))
+  /** Returns a response showing the given page. */
+  def page(page: Page): Response = Response(FXFuture.unit(page))
+  /** Returns a response showing the given node, wrapped in a Page. */
+  def node(node: javafx.scene.Node): Response = Response(FXFuture.unit(Page.fromNode(node)))
   /** Returns a response that completes once the given future response completes. */
   def fromFuture(future: FXFuture[Response]): Response = Response(future.flatMap(_.future))
-  /** Returns a response from an already computed result (a View or Redirect). */
+  /** Returns a response from an already computed result (a Page or Redirect). */
   def fromResult(result: ResponseResult): Response = Response(FXFuture.unit(result))
-  /** Returns a response from a future result (a View or Redirect). */
+  /** Returns a response from a future result (a Page or Redirect). */
   def fromFutureResult(future: FXFuture[ResponseResult]): Response = Response(future)
 }

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/RouteUtils.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/RouteUtils.scala
@@ -11,7 +11,7 @@ object RouteUtils {
 
   def transitionFilter(seconds: Double): Filter = route => { request => {
     Response(route.apply(request).future.map{
-      case x: View =>
+      case x: Page =>
         val oldNode = request.getOldContent().get()
         val newNode = x.realContent
         val t = (seconds s)
@@ -31,7 +31,7 @@ object RouteUtils {
   }}
   def sideTransitionFilter(seconds: Double): Filter = route => { request => {
     Response(route.apply(request).future.map{
-      case x: View =>
+      case x: Page =>
         val oldNode = request.getOldContent().get()
         val newNode = x.realContent
         val t = (seconds s)
@@ -59,7 +59,7 @@ object RouteUtils {
     })
   }}
 
-  def viewFromNode(x: Node): View = new View {
+  def pageFromNode(x: Node): Page = new Page {
     override def title: String = null
     override def description: String = ""
     override def content: all.Node = x

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/AppCrawler.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/AppCrawler.scala
@@ -2,7 +2,7 @@ package one.jpro.platform.routing.crawl
 
 import one.jpro.platform.routing.crawl.AppCrawler.{CrawlReportApp, CrawlReportPage}
 import one.jpro.platform.routing.sessionmanager.{SessionManager, SessionManagerDesktop, SessionManagerDummy}
-import one.jpro.platform.routing.{LinkUtil, Redirect, Request, Response, Route, RouteApp, RouteNode, SessionManagerContext, View}
+import one.jpro.platform.routing.{LinkUtil, Redirect, Request, Response, Route, RouteApp, RouteNode, SessionManagerContext, Page}
 import org.slf4j.{Logger, LoggerFactory}
 import simplefx.all._
 import simplefx.core._
@@ -25,7 +25,7 @@ object AppCrawler {
   case class CrawlReportApp(pages: java.util.List[String], reports: java.util.List[CrawlReportPage], deadLinks: java.util.List[String])
 
 
-  def crawlPage(page: View): CrawlReportPage = {
+  def crawlPage(page: Page): CrawlReportPage = {
     var foundLinks: List[LinkInfo] = Nil
     var images: List[ImageInfo] = Nil
 
@@ -82,10 +82,10 @@ object AppCrawler {
         }
       }
       if (x.isInstanceOf[ImageView]) {
-        val view = x.asInstanceOf[ImageView]
-        if (view.image != null) {
-          val url = getImageURL(view.image)
-          val description = view.accessibleRoleDescription
+        val page = x.asInstanceOf[ImageView]
+        if (page.image != null) {
+          val url = getImageURL(page.image)
+          val description = page.accessibleRoleDescription
           if (url != null) {
             images ::= ImageInfo(url, description)
           }
@@ -222,25 +222,25 @@ class AppCrawler(prefix: String, createApp: Supplier[RouteNode]) {
         enqueue(url, crawlNext)
         fromSources.foreach(src => enqueue(url, src))
 
-      case view: View =>
-        println(s"View: ${view.url} crawlNext: $crawlNext")
+      case page: Page =>
+        println(s"Page: ${page.url} crawlNext: $crawlNext")
         try {
           val newReport = inFX {
             runScheduler {
-              LinkUtil.getSessionManager(app).gotoURL(crawlNext, view, pushState = false)
-              view.url = crawlNext
+              LinkUtil.getSessionManager(app).gotoURL(crawlNext, page, pushState = false)
+              page.url = crawlNext
               assert(app.scene != null, s"Scene is null for $crawlNext")
               assert(app.scene.root != null, s"Root is null for $crawlNext")
             }
             app.scene.root.applyCss()
-            assert(view.realContent.parent != null, s"Parent is null for $crawlNext")
-            assert(view.realContent.scene != null, s"Scene is null for $crawlNext")
+            assert(page.realContent.parent != null, s"Parent is null for $crawlNext")
+            assert(page.realContent.scene != null, s"Scene is null for $crawlNext")
             println(
               "SCENE WH: " +
-                view.realContent.scene.getWidth + " " +
-                view.realContent.scene.getHeight
+                page.realContent.scene.getWidth + " " +
+                page.realContent.scene.getHeight
             )
-            AppCrawler.crawlPage(view)
+            AppCrawler.crawlPage(page)
           }
 
           reports = newReport :: reports

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/MemoryTester.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/MemoryTester.scala
@@ -5,7 +5,7 @@ import one.jpro.jmemorybuddy.JMemoryBuddy
 import javafx.stage.Stage
 import one.jpro.platform.routing.crawl.AppCrawler.{CrawlReportApp, routeToRouteNode}
 import one.jpro.platform.routing.sessionmanager.SessionManagerDesktop
-import one.jpro.platform.routing.{Request, Route, RouteApp, RouteNode, View}
+import one.jpro.platform.routing.{Request, Route, RouteApp, RouteNode, Page}
 import org.slf4j.{Logger, LoggerFactory}
 import simplefx.core._
 import simplefx.all._
@@ -28,13 +28,13 @@ object MemoryTester {
         val routeNode: RouteNode = inFX(routeToRouteNode(appFactory.get()))
         JMemoryBuddy.memoryTest(checker2 => {
           assert(routeNode != null, "The routeNode must not return null ")
-          val view = inFX(runScheduler(routeNode.getSessionManager().gotoURL(pageURL))).future.await
+          val page = inFX(runScheduler(routeNode.getSessionManager().gotoURL(pageURL))).future.await
           inFX(routeNode.scene.root.applyCss())
 
           checker2.setAsReferenced(routeNode)
-          checker2.assertCollectable(view) // Hm?
-          if(view.isInstanceOf[View]) {
-            checker2.assertCollectable(inFX(view.asInstanceOf[View].realContent))
+          checker2.assertCollectable(page) // Hm?
+          if(page.isInstanceOf[Page]) {
+            checker2.assertCollectable(inFX(page.asInstanceOf[Page].realContent))
           }
           routeNode.getSessionManager().gotoURL("/").future.await
         })
@@ -54,12 +54,12 @@ object MemoryTester {
           val result = inFX(runScheduler(routeNode.getSessionManager().gotoURL(pageURL))).future.await
 
           println("Got result: " + result)
-          if (result.isInstanceOf[View]) {
-            val view = result.asInstanceOf[View]
+          if (result.isInstanceOf[Page]) {
+            val page = result.asInstanceOf[Page]
             // Scene Graph:
-            println("Got result: " + view.realContent)
-            checker2.assertCollectable(inFX(view.realContent))
-            assert(view == routeNode.getSessionManager().getView(), "The view must be the same as in the session manager")
+            println("Got result: " + page.realContent)
+            checker2.assertCollectable(inFX(page.realContent))
+            assert(page == routeNode.getSessionManager().getPage(), "The page must be the same as in the session manager")
             inFX(routeNode.scene.root.applyCss())
           }
           routeNode.getSessionManager().gotoURL("/").future.await

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/SizeTester.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/crawl/SizeTester.scala
@@ -1,7 +1,7 @@
 package one.jpro.platform.routing.crawl
 
 import javafx.stage.Stage
-import one.jpro.platform.routing.{Request, Route, RouteNode, View}
+import one.jpro.platform.routing.{Request, Route, RouteNode, Page}
 import one.jpro.platform.routing.crawl.AppCrawler.{CrawlReportApp, routeToRouteNode}
 import org.slf4j.{Logger, LoggerFactory}
 import one.jpro.platform.scenegraph.SceneGraphSerializer
@@ -23,16 +23,16 @@ object SizeTester {
       val routeNode: RouteNode = inFX(routeToRouteNode(appFactory.get()))
       assert(routeNode != null, "The routeNode must not return null ")
 
-      val view = routeNode.getSessionManager().gotoURL(pageURL).future.await
+      val page = routeNode.getSessionManager().gotoURL(pageURL).future.await
       inFX(routeNode.scene.root.applyCss())
 
-      assert(view.isInstanceOf[View])
+      assert(page.isInstanceOf[Page])
 
       //println(SceneGraphSerializer.serialize(routeNode))
       assert(routeNode.scene != null, "The routeNode must have a scene")
 
 
-      val node = view.asInstanceOf[View].realContent
+      val node = page.asInstanceOf[Page].realContent
       waitUntil(node.scene != null)
       inFX(assert(node.scene != null, "The node must have a scene"))
       val nodeMinWidth = node.minWidth(-1)

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/ContainerFilter.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/ContainerFilter.scala
@@ -2,11 +2,11 @@ package one.jpro.platform.routing.filter.container
 
 import java.lang.ref.WeakReference
 import javafx.scene.Node
-import one.jpro.platform.routing.{Request, Response, Route, StatefulFilter, View}
+import one.jpro.platform.routing.{Request, Response, Route, StatefulFilter, Page}
 import org.slf4j.{Logger, LoggerFactory}
 
 /**
- * Base class for filters that wrap the matched view in a persistent
+ * Base class for filters that wrap the matched page in a persistent
  * "container" Node. The container is created lazily and reused across
  * navigations — only its inner content slot is swapped on each request.
  *
@@ -30,7 +30,7 @@ abstract class ContainerFilter extends StatefulFilter {
   /** Create the wrapper Node. Called at most once per filter instance. */
   def createNode(): Node
 
-  /** Replace the wrapper's content slot with the new view's content. */
+  /** Replace the wrapper's content slot with the new page's content. */
   def setContent(container: Node, content: Node): Unit
 
   /** Read the wrapper's current content slot. */
@@ -66,16 +66,16 @@ abstract class ContainerFilter extends StatefulFilter {
 
     val r = route.apply(request2)
     Response(r.future.map {
-      case view: View =>
+      case page: Page =>
         var container = containerRef.get()
         if (container == null) {
           container = createNode()
           containerRef = new WeakReference(container)
         }
         val finalContainer = container
-        view.mapContent { _ =>
+        page.mapContent { _ =>
           setRequest(finalContainer, request)
-          setContent(finalContainer, view.realContent)
+          setContent(finalContainer, page.realContent)
           finalContainer
         }
       case other => other

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/StyleClassFilter.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/StyleClassFilter.scala
@@ -5,7 +5,7 @@ import javafx.scene.Node
 import javafx.scene.layout.StackPane
 
 /**
- * A [[ContainerFilter]] that wraps the matched view in a `StackPane` whose
+ * A [[ContainerFilter]] that wraps the matched page in a `StackPane` whose
  * `getStyleClass()` mirrors a caller-supplied `ObservableList[String]`.
  *
  * The mirror image of [[StylesheetsFilter]] but for style classes instead of

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/StylesheetsFilter.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/filter/container/StylesheetsFilter.scala
@@ -5,7 +5,7 @@ import javafx.scene.Node
 import javafx.scene.layout.StackPane
 
 /**
- * A [[ContainerFilter]] that wraps the matched view in a `StackPane` whose
+ * A [[ContainerFilter]] that wraps the matched page in a `StackPane` whose
  * `getStylesheets()` mirrors a caller-supplied `ObservableList[String]`.
  * Stylesheets attach to the wrapper Parent (not the Scene), so CSS scoped to
  * one sub-route subtree cannot bleed into siblings. Mutating the source list

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/performance/IncrementalLoading.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/performance/IncrementalLoading.scala
@@ -60,8 +60,8 @@ object IncrementalLoading {
 
       val sm: SessionManager = SessionManagerContext.getContext(x)
       if(sm == null) throw new RuntimeException("No JPro Rotuing SessionManager found")
-      val view = sm.view
-      val content = view.realContent
+      val page = sm.page
+      val content = page.realContent
       if(!content.getProperties.containsKey(IncrementalLoadingKey)) {
         val loader = new IncrementalLoader(content)
         content.getProperties.put(IncrementalLoadingKey, loader)

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManager.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManager.scala
@@ -4,7 +4,7 @@ import com.jpro.webapi.WebAPI
 import one.jpro.jmemorybuddy.JMemoryBuddyLive
 import javafx.beans.property.{ObjectProperty, SimpleObjectProperty}
 import javafx.collections.{FXCollections, ObservableList}
-import one.jpro.platform.routing.{HistoryEntry, Request, Response, ResponseResult, RouteNode, SessionManagerContext, View}
+import one.jpro.platform.routing.{HistoryEntry, Request, Response, ResponseResult, RouteNode, SessionManagerContext, Page}
 import org.slf4j.{Logger, LoggerFactory}
 import simplefx.all._
 import simplefx.core._
@@ -16,7 +16,7 @@ import java.util.function.Consumer
 
 
 /**
- * Manages the navigation of a routing application: the current URL and view,
+ * Manages the navigation of a routing application: the current URL and page,
  * the history, and programmatic navigation via {@code gotoURL}. There is one
  * SessionManager per application; obtain it via {@code RouteApp.getSessionManager()}
  * or {@code LinkUtil.getSessionManager(node)}. In the browser it is backed by the
@@ -41,10 +41,10 @@ trait SessionManager { THIS =>
   @Bind var historyForward : List[HistoryEntry] = getHistoryForwards.toBindable
 
   @Bind var url: String = null
-  @Bind var view: View = null
+  @Bind var page: Page = null
 
-  /** Returns the currently shown view. */
-  def getView(): View = view
+  /** Returns the currently shown page. */
+  def getPage(): Page = page
   /** Returns the URL currently shown. */
   def getURL(): String = url
 
@@ -92,7 +92,7 @@ trait SessionManager { THIS =>
     try {
       logger.debug(s"goto: $url2")
       val request = getRequest(url2)
-      val newView = if(view != null && view.handleRequest(request)) Response(FXFuture(view)) else {
+      val newView = if(page != null && page.handleRequest(request)) Response(FXFuture(page)) else {
         webApp.getRoute()(request)
       }
       Response.fromFuture(newView.future.map { response =>
@@ -109,27 +109,27 @@ trait SessionManager { THIS =>
   def gotoURL(_url: String, x: ResponseResult, pushState: Boolean): Response
 
   def getRequest(url: String): Request = {
-    val node = if(view == null) null else view.realContent
+    val node = if(page == null) null else page.realContent
     Request.fromString(url, node)
   }
 
   def start(): Response
 
-  def markViewCollectable(view: View): Unit = {
-    JMemoryBuddyLive.markCollectable(s"Page url: ${view.url} title: ${view.title}", view.realContent)
+  def markPageCollectable(page: Page): Unit = {
+    JMemoryBuddyLive.markCollectable(s"Page url: ${page.url} title: ${page.title}", page.realContent)
   }
-  def markViewCollectable(oldView: View, newView: View): Unit = {
-//    logger.debug(s"depths: ${viewDepth(oldView)} - ${viewDepth(newView)}")
+  def markPageCollectable(oldView: Page, newView: Page): Unit = {
+//    logger.debug(s"depths: ${pageDepth(oldView)} - ${pageDepth(newView)}")
     if(oldView.realContent != newView.realContent) {
 //      logger.debug(s"nodes: ${oldView.realContent} - ${newView.realContent}")
       JMemoryBuddyLive.markCollectable(s"Page url: ${oldView.url} title: ${oldView.title}", oldView.realContent)
     }
-    if(oldView.subView() != null && newView.subView != null) {
-      markViewCollectable(oldView.subView(), newView.subView())
+    if(oldView.subPage() != null && newView.subPage != null) {
+      markPageCollectable(oldView.subPage(), newView.subPage())
     }
   }
-  def viewDepth(x: View): Int = {
-    if(x.subView() == null) 1 else 1 + viewDepth(x.subView())
+  def pageDepth(x: Page): Int = {
+    if(x.subPage() == null) 1 else 1 + pageDepth(x.subPage())
   }
 }
 

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManagerDesktop.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManagerDesktop.scala
@@ -31,31 +31,31 @@ class SessionManagerDesktop(val webApp: RouteNode) extends SessionManager { THIS
       case Redirect(url) =>
         logger.debug(s"redirect: ${_url} -> $url")
         redirect(url, _url)
-      case view: View =>
+      case page: Page =>
         redirectCounter = 0
-        val oldView = this.view
-        this.view = view
-        view.setSessionManager(this)
-        view.url = url
+        val oldView = this.page
+        this.page = page
+        page.setSessionManager(this)
+        page.url = url
 
-        isFullscreen = view.fullscreen
-        container.children = List(view.realContent)
+        isFullscreen = page.fullscreen
+        container.children = List(page.realContent)
         scrollpane.vvalue = 0.0
-        if(oldView != null && oldView != view) {
+        if(oldView != null && oldView != page) {
           oldView.onClose()
           oldView.setSessionManager(null)
-          markViewCollectable(oldView, view)
+          markPageCollectable(oldView, page)
         }
-        THIS.view = view
+        THIS.page = page
 
         if(pushState ) {
           historyForward = Nil
           if(historyCurrent != null) {
             historyBackward = historyCurrent :: historyBackward
           }
-          historyCurrent = HistoryEntry(url, view.title)
+          historyCurrent = HistoryEntry(url, page.title)
         }
-        Response.view(view)
+        Response.page(page)
     }
   }
   val container = new StackPane()
@@ -78,7 +78,7 @@ class SessionManagerDesktop(val webApp: RouteNode) extends SessionManager { THIS
   onceWhen(webApp.scene != null && webApp.scene.window != null) --> {
     val window = webApp.scene.window
     if(window.isInstanceOf[Stage]) {
-      window.asInstanceOf[Stage].title <-- (if(view != null) view.title else "")
+      window.asInstanceOf[Stage].title <-- (if(page != null) page.title else "")
     }
   }
 

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManagerWeb.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/sessionmanager/SessionManagerWeb.scala
@@ -1,7 +1,7 @@
 package one.jpro.platform.routing.sessionmanager
 
 import com.jpro.webapi.WebAPI
-import one.jpro.platform.routing.{Redirect, Response, ResponseResult, RouteNode, View}
+import one.jpro.platform.routing.{Redirect, Response, ResponseResult, RouteNode, Page}
 import org.slf4j.{Logger, LoggerFactory}
 import simplefx.all._
 
@@ -24,11 +24,11 @@ class SessionManagerWeb(val webApp: RouteNode, val webAPI: WebAPI) extends Sessi
 
   if(webAPI != null) { // somtetimes webAPI is null, for example when crawling
     webAPI.addInstanceCloseListener(() => {
-      // if the session only has redirects, the view is null
-      if (THIS.view != null) {
-        THIS.view.onClose()
-        THIS.view.setSessionManager(null)
-        markViewCollectable(THIS.view)
+      // if the session only has redirects, the page is null
+      if (THIS.page != null) {
+        THIS.page.onClose()
+        THIS.page.setSessionManager(null)
+        markPageCollectable(THIS.page)
       }
     })
   }
@@ -44,21 +44,21 @@ class SessionManagerWeb(val webApp: RouteNode, val webAPI: WebAPI) extends Sessi
         } else {
           redirect(url, _url)
         }
-      case view: View =>
+      case page: Page =>
         redirectCounter = 0
         this.url = url
-        view.setSessionManager(this)
-        view.url = url
+        page.setSessionManager(this)
+        page.url = url
 
-        view.isMobile = webAPI.isMobile
+        page.isMobile = webAPI.isMobile
 
-        container.children = List(view.realContent)
-        if(THIS.view != null && THIS.view != view) {
-          THIS.view.onClose()
-          THIS.view.setSessionManager(null)
-          markViewCollectable(THIS.view, view)
+        container.children = List(page.realContent)
+        if(THIS.page != null && THIS.page != page) {
+          THIS.page.onClose()
+          THIS.page.setSessionManager(null)
+          markPageCollectable(THIS.page, page)
         }
-        THIS.view = view
+        THIS.page = page
 
 
         if(pushState) {
@@ -68,9 +68,9 @@ class SessionManagerWeb(val webApp: RouteNode, val webAPI: WebAPI) extends Sessi
           //                        |scrollTop: (window.pageYOffset || doc.scrollTop)  - (doc.clientTop || 0)
           //                        |}, null, null);
           //                        |""".stripMargin)
-          webAPI.js().eval(s"""history.pushState(null, null, "${view.url.replace("\"","\\\"")}");""")
+          webAPI.js().eval(s"""history.pushState(null, null, "${page.url.replace("\"","\\\"")}");""")
         }
-        val initialState = if(view.saveScrollPosition) "{saveScroll: true}" else "{saveScroll: false}"
+        val initialState = if(page.saveScrollPosition) "{saveScroll: true}" else "{saveScroll: false}"
 
         webAPI.js().eval(
           """var scrollY = 0;
@@ -79,9 +79,9 @@ class SessionManagerWeb(val webApp: RouteNode, val webAPI: WebAPI) extends Sessi
             |}
             |scroll(0,scrollY)
           """.stripMargin)
-        webAPI.js().eval(s"""document.getElementsByTagName("jpro-app")[0].sfxelem.setFXHeight(${!view.fullscreen})""")
-        webAPI.js().eval(s"""document.title = "${Option(view.title).getOrElse("").replace("\"","\\\"")}";""")
-        webAPI.js().eval(s"""document.querySelector('meta[name="description"]').setAttribute("content", "${Option(view.description).getOrElse("").replace("\"","\\\"")}");""")
+        webAPI.js().eval(s"""document.getElementsByTagName("jpro-app")[0].sfxelem.setFXHeight(${!page.fullscreen})""")
+        webAPI.js().eval(s"""document.title = "${Option(page.title).getOrElse("").replace("\"","\\\"")}";""")
+        webAPI.js().eval(s"""document.querySelector('meta[name="description"]').setAttribute("content", "${Option(page.description).getOrElse("").replace("\"","\\\"")}");""")
         webAPI.js().eval(s"history.replaceState($initialState, null, null)")
         Response.fromResult(x)
     }

--- a/jpro-routing/dev/src/main/scala/one/jpro/platform/routing/dev/DevFilter.scala
+++ b/jpro-routing/dev/src/main/scala/one/jpro/platform/routing/dev/DevFilter.scala
@@ -70,7 +70,7 @@ object DevFilter {
           LinkUtil.gotoPage(this, getText())
         }
       }
-      this <++ new Button("Scenic View") {
+      this <++ new Button("Scenic Page") {
         onAction --> {
           if (WebAPI.isBrowser) {
             val stage = new Stage()

--- a/jpro-routing/example/src/main/scala/example/scala/TestWebApplication.scala
+++ b/jpro-routing/example/src/main/scala/example/scala/TestWebApplication.scala
@@ -22,28 +22,28 @@ class TestWebApplication extends RouteApp {
     }
 
     Route.empty()
-      .and(get("", (r) => Response.view(new MainView)))
-      .and(get("/", (r) => Response.view(new MainView)))
+      .and(get("", (r) => Response.page(new MainView)))
+      .and(get("/", (r) => Response.page(new MainView)))
       .and(get("/redirect2", r => Response.redirect("https://google.com")))
-      .and(get("/main", (r) => Response.view(new MainView)))
-      .and(get("/green", (r) => Response.view(new GreenView)))
-      .and(get("/sub", (r) => Response.view(new SubView)))
+      .and(get("/main", (r) => Response.page(new MainView)))
+      .and(get("/green", (r) => Response.page(new GreenView)))
+      .and(get("/sub", (r) => Response.page(new SubView)))
       .and(get("/redirect", r => Response.redirect( "/sub")))
-      .and(get("/paralax", (r) => Response.view(new ParalaxPage)))
-      .and(get("/pdf", (r) => Response.view(new PDFTest)))
-      .and(get("/leak", (r) => Response.view(new LeakingPage)))
-      .and(get("/collect", (r) => Response.view(new CollectingPage)))
-      .and(get("/incremental", (r) => Response.view(new IncrementalPage)))
-      .and(get("/jmemorybuddy", (r) => Response.view(new JMemoryBuddyPage)))
-      .and(get("/100", (r) => Response.view(new ManyNodes(100))))
-      .and(get("/200", (r) => Response.view(new ManyNodes(200))))
-      .and(get("/400", (r) => Response.view(new ManyNodes(400))))
-      .and(get("/800", (r) => Response.view(new ManyNodes(800))))
-      .and(get("/1600", (r) => Response.view(new ManyNodes(1600))))
-      .and(get("/3200", (r) => Response.view(new ManyNodes(3200))))
-      .and(get("/6400", (r) => Response.view(new ManyNodes(6400))))
-      .and(get("/it's\" tricky", (r) => Response.view(new MainView)))
-      .and(get("/it's\" tricky", (r) => Response.view(new MainView)))
+      .and(get("/paralax", (r) => Response.page(new ParalaxPage)))
+      .and(get("/pdf", (r) => Response.page(new PDFTest)))
+      .and(get("/leak", (r) => Response.page(new LeakingPage)))
+      .and(get("/collect", (r) => Response.page(new CollectingPage)))
+      .and(get("/incremental", (r) => Response.page(new IncrementalPage)))
+      .and(get("/jmemorybuddy", (r) => Response.page(new JMemoryBuddyPage)))
+      .and(get("/100", (r) => Response.page(new ManyNodes(100))))
+      .and(get("/200", (r) => Response.page(new ManyNodes(200))))
+      .and(get("/400", (r) => Response.page(new ManyNodes(400))))
+      .and(get("/800", (r) => Response.page(new ManyNodes(800))))
+      .and(get("/1600", (r) => Response.page(new ManyNodes(1600))))
+      .and(get("/3200", (r) => Response.page(new ManyNodes(3200))))
+      .and(get("/6400", (r) => Response.page(new ManyNodes(6400))))
+      .and(get("/it's\" tricky", (r) => Response.page(new MainView)))
+      .and(get("/it's\" tricky", (r) => Response.page(new MainView)))
       .filter(DevFilter.create)
       .filter(StatisticsFilter.create)
   }
@@ -51,7 +51,7 @@ class TestWebApplication extends RouteApp {
 
 }
 
-class Header(view: View, sessionManager: SessionManager) extends HBox {
+class Header(page: Page, sessionManager: SessionManager) extends HBox {
   padding = Insets(10)
   spacing = 10
   class HeaderLink(str: String, url: String) extends Label (str) {
@@ -93,8 +93,8 @@ class Header(view: View, sessionManager: SessionManager) extends HBox {
     setLink(this, "/?7", Some("/?7"))
   }
 }
-class Header2(view: View, sessionManager: SessionManager) extends HBox {
-  this <++ new Label(view.url)
+class Header2(page: Page, sessionManager: SessionManager) extends HBox {
+  this <++ new Label(page.url)
 
   this <++ new Button("Backward") {
     disable <-- (!WebAPI.isBrowser && sessionManager.historyBackward.isEmpty)
@@ -110,8 +110,8 @@ class Header2(view: View, sessionManager: SessionManager) extends HBox {
   }
   this <++ new Button("Backward2") {
     onAction --> { e =>
-      println("view.getSessionManager(): " + view.getSessionManager())
-      view.getSessionManager().goBack()
+      println("page.getSessionManager(): " + page.getSessionManager())
+      page.getSessionManager().goBack()
     }
   }
 }
@@ -127,14 +127,14 @@ class Footer(sessionManager: SessionManager) extends HBox {
   }
 }
 
-trait Page extends View { view =>
+trait SitePage extends Page { page =>
   override lazy val realContent: VBox = {
     new VBox {
   // Cousing leak? style = "-fx-background-color: white;"
     //  transform = Scale(1.3,1.3)
       spacing = 10
-      this <++ new Header(view, getSessionManager)
-      this <++ new Header2(view, getSessionManager)
+      this <++ new Header(page, getSessionManager)
+      this <++ new Header2(page, getSessionManager)
       val theContent = content
       javafx.scene.layout.VBox.setVgrow(theContent,Priority.ALWAYS)
       this <++ theContent
@@ -148,7 +148,7 @@ trait Page extends View { view =>
   }
 }
 
-class UnknownPage(x: String) extends Page {
+class UnknownPage(x: String) extends SitePage {
   def title = "Unknown page: " + x
   def description = "Unknown page: " + x
 
@@ -157,7 +157,7 @@ class UnknownPage(x: String) extends Page {
   def content = new Label("UNKNOWN PAGE: " + x) { font = new Font(60)}
 }
 
-class GreenView() extends Page {
+class GreenView() extends SitePage {
   def title = "Green Page"
   def description = "desc Main"
 
@@ -166,7 +166,7 @@ class GreenView() extends Page {
   def content = new StackPane { style = "-fx-background-color: green;"}
 }
 
-class MainView extends Page {
+class MainView extends SitePage {
   def title = "Main"
   def description = "desc Main"
 
@@ -226,7 +226,7 @@ class MainView extends Page {
   }
 }
 
-class ManyNodes(size: Int) extends Page {
+class ManyNodes(size: Int) extends SitePage {
   def title = "ManyNodes " + size
 
   def description = "desc ManyNodes"
@@ -244,7 +244,7 @@ class ManyNodes(size: Int) extends Page {
   }
 }
 
-class SubView extends Page {
+class SubView extends SitePage {
   def title = "SubView"
   def description = "desc Sub"
   override def fullscreen=false
@@ -258,7 +258,7 @@ class SubView extends Page {
   }
 }
 
-class IncrementalPage extends Page {
+class IncrementalPage extends SitePage {
   def title = "Incremental"
   def description = "desc Incremental"
 
@@ -271,7 +271,7 @@ class IncrementalPage extends Page {
   }
 }
 
-class PDFTest extends Page {
+class PDFTest extends SitePage {
   def title = "pdf"
   def description = "pdf desc"
 
@@ -286,7 +286,7 @@ class PDFTest extends Page {
 object LeakingPage {
   var instances: List[Page] = Nil
 }
-class LeakingPage extends Page {
+class LeakingPage extends SitePage {
   def title = "leak"
   def description = "leaks"
 
@@ -296,7 +296,7 @@ class LeakingPage extends Page {
     this <++ new Label("Leaks") { font = new Font(60)}
   }
 }
-class CollectingPage extends Page {
+class CollectingPage extends SitePage {
   def title = "collect"
   def description = "collect"
 
@@ -311,7 +311,7 @@ class CollectingPage extends Page {
     this <++ new Label("Leaks") { font = new Font(60)}
   }
 }
-class JMemoryBuddyPage extends Page {
+class JMemoryBuddyPage extends SitePage {
   def title = "buddy"
   def description = "buddy"
 
@@ -329,7 +329,7 @@ class JMemoryBuddyPage extends Page {
   }
 }
 
-class ParalaxPage extends Page {
+class ParalaxPage extends SitePage {
   def title = "Paralax"
   def description = "desc Para"
 

--- a/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/videoroom/VideoRoomApp.java
+++ b/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/videoroom/VideoRoomApp.java
@@ -7,7 +7,7 @@ import simplefx.experimental.parts.FXFuture;
 
 import java.util.regex.Pattern;
 
-import static one.jpro.platform.routing.RouteUtils.viewFromNode;
+import static one.jpro.platform.routing.RouteUtils.pageFromNode;
 
 public class VideoRoomApp extends RouteApp {
 


### PR DESCRIPTION
Renames `View` → `Page` across jpro-routing — the historic name never matched the routing/web vocabulary (routes, pages, SEO, sitemaps), and the docs already reached for "Page".

Clean rename, **no compatibility alias** (few users; CHANGELOG note covers migration). Surface:
- `View` → `Page` (class), `NodeView` → `NodePage`
- `Response.view(...)` → `Response.page(...)`
- `SessionManager.getView()` → `getPage()`, internal `view` field → `page`
- `View.fromNode` → `Page.fromNode`, `subView` → `subPage`, `markViewCollectable` → `markPageCollectable`
- README "Views" chapter → "Pages"; examples updated (example's local `Page` layout trait renamed to `SitePage` to avoid collision)

Core, dev, popup, example all compile; core-test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)