### PR TITLE
Add Filters.mapPage and Page.with* methods; rename FullscreenFilter to fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ### 0.6.4 (unreleased)
 
+#### Features
+* `jpro-routing`: `Filters.mapPage(Page -> Page)` applies a transform to the route's pages, leaving redirects and empty responses untouched.
+* `jpro-routing`: `Page.withTitle`, `Page.withDescription`, `Page.withFullscreen` return a copy of a page with one property changed.
+
 #### Improvements
 * `jpro-routing`: Documented Pages, filters, containers, popups and dev tools in the README.
+* `jpro-routing`: Page-decorating filters now preserve all page properties (`onClose`, `saveScrollPosition`, `handleRequest`, `subPage`), not only title/description/content/fullscreen.
 
 #### Breaking
 * `jpro-routing`: Renamed `View` to `Page`. Affects `Response.page(...)` (was `Response.view`), `SessionManager.getPage()` (was `getView`), `Page.fromNode(...)`, `subPage()`, and `NodePage`.
+* `jpro-routing`: Renamed `Filters.FullscreenFilter(...)` to `Filters.fullscreen(...)`, for consistency with `Filters.title`/`description`.
 
 ### 0.6.3 (May 25, 2026)
 

--- a/example/src/main/java/one/jpro/platform/example/Main.java
+++ b/example/src/main/java/one/jpro/platform/example/Main.java
@@ -66,6 +66,6 @@ public class Main extends RouteApp {
                 .and(get(sessionManagerLink.prefix(), request ->
                         Response.node(new SessionManagerSample().createRoot(getStage()))))
                 .filter(LinkHeaderFilter.create(links))
-                .filter(Filters.FullscreenFilter(true));
+                .filter(Filters.fullscreen(true));
     }
 }

--- a/jpro-routing/README.md
+++ b/jpro-routing/README.md
@@ -165,7 +165,7 @@ On the browser, scrollable uses the native scrolling of the browser.
 
 This can be configured with the following methods
 1. Override the method `Page.fullscreen()` in your Page
-2. Use the filter `Filters.FullscreenFilter(boolean)` to set it for a Route
+2. Use the filter `Filters.fullscreen(boolean)` to set it for a Route
 
 
 ### History API and defaultpage
@@ -205,7 +205,7 @@ A `Filter` wraps a `Route` and can decorate every page. The library ships severa
 
 ```java
 route
-    .filter(Filters.FullscreenFilter(true))                  // force fullscreen
+    .filter(Filters.fullscreen(true))                  // force fullscreen
     .filter(Filters.titleAndDescription("My App", "..."))    // default title/description
     .filter(Filters.stylesheets(new String[]{"/css/main.css"})) // wrap pages with stylesheets
     .filter(Filters.styleClasses(new String[]{"dark-theme"}))   // wrap pages with style classes

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Filters.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Filters.scala
@@ -80,74 +80,33 @@ object Filters {
     new StyleClassFilter(list)
   }
 
-  def FullscreenFilter(fullscreenValue: Boolean): Filter = { route => { request =>
-      val r = route.apply(request)
+  // ----- Page transforms -----
 
-      Response(r.future.map {
-        case x: Page =>
-          new Page {
-            override def title: String = x.title
-            override def description: String = x.description
-            override def content: all.Node = x.realContent
-
-            override def fullscreen: Boolean = fullscreenValue
-          }
+  /**
+   * Applies {@code f} to the page produced by the route, leaving redirects and
+   * empty responses untouched. The building block for page-decorating filters
+   * such as {@link #fullscreen}, {@link #title} and {@link #description}.
+   */
+  def mapPage(f: Function[Page, Page]): Filter = { route => { request =>
+      Response(route.apply(request).future.map {
+        case page: Page => f.apply(page)
         case x => x
       })
     }
   }
-  def title(title: String): Filter = { route => { request =>
-      val r = route.apply(request)
-      val _title = title
 
-      Response(r.future.map {
-        case x: Page =>
-          new Page {
-            override def title: String = _title
-            override def description: String = x.description
-            override def content: all.Node = x.realContent
+  /** Sets the fullscreen flag of the route's pages. */
+  def fullscreen(fullscreenValue: Boolean): Filter = mapPage(_.withFullscreen(fullscreenValue))
 
-            override def fullscreen: Boolean = x.fullscreen
-          }
-        case x => x
-      })
-    }
-  }
-  def description(description: String): Filter = { route => { request =>
-      val r = route.apply(request)
-      val _description = description
+  /** Sets the title of the route's pages. */
+  def title(title: String): Filter = mapPage(_.withTitle(title))
 
-      Response(r.future.map {
-        case x: Page =>
-          new Page {
-            override def title: String = x.title
-            override def description: String = _description
-            override def content: all.Node = x.realContent
+  /** Sets the description of the route's pages. */
+  def description(description: String): Filter = mapPage(_.withDescription(description))
 
-            override def fullscreen: Boolean = x.fullscreen
-          }
-        case x => x
-      })
-    }
-  }
-  def titleAndDescription(title: String, description: String): Filter = { route => { request =>
-      val r = route.apply(request)
-      val _title = title
-      val _description = description
-
-      Response(r.future.map {
-        case x: Page =>
-          new Page {
-            override def title: String = _title
-            override def description: String = _description
-            override def content: all.Node = x.realContent
-
-            override def fullscreen: Boolean = x.fullscreen
-          }
-        case x => x
-      })
-    }
-  }
+  /** Sets the title and description of the route's pages. */
+  def titleAndDescription(title: String, description: String): Filter =
+    mapPage(_.withTitle(title).withDescription(description))
 
   def errorPage(): Filter = errorPage((request, ex) => Response.node(new Label("Error: " + ex.getMessage)))
   def errorPage(biFunction: BiFunction[Request, Throwable, Response]): Filter = {

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Page.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Page.scala
@@ -34,21 +34,47 @@ abstract class Page extends ResponseResult { THIS =>
    * @return whether the page handles the url change
    */
   def handleRequest(x: Request): Boolean = false
-  def mapContent(f: Node => Node): Page = new Page {
-    override def title: String = THIS.title
 
-    override def description: String = THIS.description
+  /** Returns a copy of this page with the content mapped through {@code f}. */
+  def mapContent(f: Node => Node): Page = new DelegatingPage(THIS) {
+    override protected def content: Node = f(THIS.realContent)
+  }
 
-    override def content: all.Node = f(THIS.realContent)
+  /** Returns a copy of this page with a different title. */
+  def withTitle(title: String): Page = {
+    val _title = title
+    new DelegatingPage(THIS) { override def title: String = _title }
+  }
 
-    override def fullscreen: Boolean = THIS.fullscreen
+  /** Returns a copy of this page with a different description. */
+  def withDescription(description: String): Page = {
+    val _description = description
+    new DelegatingPage(THIS) { override def description: String = _description }
+  }
 
-    override def setSessionManager(x: SessionManager): Unit = {
-      super.setSessionManager(x)
-      THIS.setSessionManager(x)
-    }
+  /** Returns a copy of this page with a different fullscreen setting. */
+  def withFullscreen(fullscreen: Boolean): Page = {
+    val _fullscreen = fullscreen
+    new DelegatingPage(THIS) { override def fullscreen: Boolean = _fullscreen }
+  }
+}
 
-    override def subPage(): Page = THIS
+/**
+ * A page that forwards every property to {@code original}. Used by the {@code with*}
+ * copy methods and {@code mapContent}: subclass it and override the one member to change.
+ */
+private[routing] class DelegatingPage(original: Page) extends Page {
+  override def title: String = original.title
+  override def description: String = original.description
+  override protected def content: Node = original.realContent
+  override def fullscreen: Boolean = original.fullscreen
+  override def saveScrollPosition: Boolean = original.saveScrollPosition
+  override def handleRequest(x: Request): Boolean = original.handleRequest(x)
+  override def onClose(): Unit = original.onClose()
+  override def subPage(): Page = original
+  override def setSessionManager(x: SessionManager): Unit = {
+    super.setSessionManager(x)
+    original.setSessionManager(x)
   }
 }
 

--- a/jpro-routing/example/src/main/java/example/colors/ColorsApp.java
+++ b/jpro-routing/example/src/main/java/example/colors/ColorsApp.java
@@ -49,7 +49,7 @@ public class ColorsApp extends RouteApp {
                         Route.empty()
                                 .and(Route.get("/green", (r) -> gen("Green", r.resolve("/red"), Color.GREEN)))
                                 .and(Route.get("/red", (r) -> gen("Red", r.resolve("/green"), Color.RED))))
-                .filter(Filters.FullscreenFilter(true))
+                .filter(Filters.fullscreen(true))
                 .filter(RouteUtils.sideTransitionFilter(1))
                 .filter(DevFilter.create())
                 .filter(StatisticsFilter.create())

--- a/jpro-routing/example/src/main/java/example/popup/PopupApp.java
+++ b/jpro-routing/example/src/main/java/example/popup/PopupApp.java
@@ -30,7 +30,7 @@ public class PopupApp extends RouteApp {
         return Route.empty()
                 .and(redirect("/", "/popup"))
                 .and(get("/popup", (r) -> Response.node(popupSampleButtons())))
-                .filter(Filters.FullscreenFilter(true))
+                .filter(Filters.fullscreen(true))
                 .filter(DevFilter.create())
                 .filter(PopupAPI.createPopupContainerFilter())
                 ;

--- a/jpro-routing/example/src/main/scala/example/scala/ColorTransition.scala
+++ b/jpro-routing/example/src/main/scala/example/scala/ColorTransition.scala
@@ -37,7 +37,7 @@ class ColorTransition(stage: Stage) extends RouteNode(stage) {
       )
       // Alternative names: with, apply, map, use, modify, wrap, transform
       // enhancer, operations
-      .filter(Filters.FullscreenFilter(true))
+      .filter(Filters.fullscreen(true))
       .filter(RouteUtils.sideTransitionFilter(1))
       .filter(DevFilter.create())
   )

--- a/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/videoroom/VideoRoomApp.java
+++ b/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/videoroom/VideoRoomApp.java
@@ -32,6 +32,6 @@ public class VideoRoomApp extends RouteApp {
                         return Response.empty();
                     }
                 })
-                .filter(Filters.FullscreenFilter(true));
+                .filter(Filters.fullscreen(true));
     }
 }


### PR DESCRIPTION
Builds on the page/filter cleanup:

- **`Filters.mapPage(Page -> Page)`** — building block that applies a transform to the route's pages (redirects/empty pass through). Java-friendly (`java.util.function.Function`).
- **`Page.withTitle` / `withDescription` / `withFullscreen`** — return a copy of a page with one property changed.
- **`Filters.fullscreen(...)`** replaces `Filters.FullscreenFilter(...)`, matching the lowercase `title`/`description` mutators.
- The four built-in page-decorating filters (`fullscreen`/`title`/`description`/`titleAndDescription`) are reimplemented on `mapPage` + `with*`, collapsing ~65 lines of duplicated `new Page {…}` blocks.
- A complete `DelegatingPage` backs the copies and now preserves all page properties (`onClose`, `saveScrollPosition`, `handleRequest`, `subPage`), which the old hand-rolled copies dropped — likely fixing latent bugs where those were lost after a filter.

Whole-build compiles; routing tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)