### PR TITLE
tagRelease.sh: require project name (wrong-repo guard)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,10 @@ The derived version is printed at the start of every build.
 ## Releasing a version
 
 ```bash
-./tagRelease.sh 0.7.0
+./tagRelease.sh jpro-platform 0.7.0
 ```
+
+The first argument is the project name, guarding against running this in the wrong repo.
 
 The script only tags: it verifies a clean tree on an up-to-date `main` and a dated
 `### 0.7.0` CHANGELOG entry, then tags and pushes `0.7.0`. The tag push triggers
@@ -36,7 +38,7 @@ become `X.Y.(Z+1)-SNAPSHOT`.
 
 ## Notes
 
-- Transition: the latest existing tag is `0.6.3`, so until the first `0.7.0` tag exists, builds derive `0.6.4-SNAPSHOT` even though the next release is `0.7.0`. The first `./tagRelease.sh 0.7.0` realigns everything.
-- To release `0.7.0`: set the date on the `### 0.7.0` CHANGELOG entry (remove `(unreleased)`), commit, then `./tagRelease.sh 0.7.0`.
+- Transition: the latest existing tag is `0.6.3`, so until the first `0.7.0` tag exists, builds derive `0.6.4-SNAPSHOT` even though the next release is `0.7.0`. The first `./tagRelease.sh jpro-platform 0.7.0` realigns everything.
+- To release `0.7.0`: set the date on the `### 0.7.0` CHANGELOG entry (remove `(unreleased)`), commit, then `./tagRelease.sh jpro-platform 0.7.0`.
 - CI checkouts use `fetch-depth: 0` (configured) — a shallow clone can't see tags and would fall back to the SNAPSHOT default.
 - Set `MAVEN_CENTRAL_PUBLISHING_TYPE=USER_MANAGED` to review the deployment in the portal before it goes live; default is `AUTOMATIC`.

--- a/tagRelease.sh
+++ b/tagRelease.sh
@@ -4,9 +4,16 @@
 # Tags have no prefix, matching this repository's existing tags.
 set -e
 
-VERSION=$1
+# First arg is the project name, guarding against running this in the wrong repo.
+PROJECT="jpro-platform"
+if [ "$1" != "$PROJECT" ]; then
+    echo "usage: ./tagRelease.sh $PROJECT X.Y.Z"
+    exit 1
+fi
+
+VERSION=$2
 if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "usage: ./tagRelease.sh X.Y.Z"
+    echo "usage: ./tagRelease.sh $PROJECT X.Y.Z"
     exit 1
 fi
 


### PR DESCRIPTION
Adds a required project-name first argument so pasting the command in the wrong repo is rejected: `./tagRelease.sh jpro-platform X.Y.Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)