### PR TITLE
Docs & API cleanups for jpro-routing and jpro-auth-routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ and OAuth2 (and to some extent OpenID Connect) implementation.
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-auth-core</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -71,7 +71,7 @@ and OAuth2 (and to some extent OpenID Connect) implementation.
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-auth-core:0.6.3")
+    implementation("one.jpro.platform:jpro-auth-core:0.7.1")
 }
 ```
 
@@ -84,7 +84,7 @@ Creates human and AI friendly String representations of JavaFX SceneGraphs.
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-scenegraph</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -92,7 +92,7 @@ Creates human and AI friendly String representations of JavaFX SceneGraphs.
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-scenegraph:0.6.3")
+    implementation("one.jpro.platform:jpro-scenegraph:0.7.1")
 }
 ```
 
@@ -105,7 +105,7 @@ This library provides a simple way to pick, drop, upload and download files in *
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-file</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -113,7 +113,7 @@ This library provides a simple way to pick, drop, upload and download files in *
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-file:0.6.3")
+    implementation("one.jpro.platform:jpro-file:0.7.1")
 }
 ```
 
@@ -149,7 +149,7 @@ to the desired size.
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-image-manager</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -157,7 +157,7 @@ to the desired size.
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-image-manager:0.6.3")
+    implementation("one.jpro.platform:jpro-image-manager:0.7.1")
 }
 ```
 
@@ -171,7 +171,7 @@ using SMTP and SMTPS protocols. It also provides a simple way to compose and sen
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-mail</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -179,7 +179,7 @@ using SMTP and SMTPS protocols. It also provides a simple way to compose and sen
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-mail:0.6.3")
+    implementation("one.jpro.platform:jpro-mail:0.7.1")
 }
 ```
 
@@ -194,7 +194,7 @@ all while utilizing the same codebase.
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-media</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 
   <dependency>
@@ -215,7 +215,7 @@ plugins {
 }
 
 dependencies {
-    implementation("one.jpro.platform:jpro-media:0.6.3")
+    implementation("one.jpro.platform:jpro-media:0.7.1")
     implementation "org.bytedeco:javacv-platform:1.5.10" // use compileOnly configuration when running/deploying with JPro
 }
 ```
@@ -233,7 +233,7 @@ Currently, there are three routing modules available:
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-routing-core</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -241,7 +241,7 @@ Currently, there are three routing modules available:
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-routing-core:0.6.3")
+    implementation("one.jpro.platform:jpro-routing-core:0.7.1")
 }
 ```
 
@@ -253,7 +253,7 @@ dependencies {
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-routing-dev</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -261,7 +261,7 @@ dependencies {
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-routing-dev:0.6.3")
+    implementation("one.jpro.platform:jpro-routing-dev:0.7.1")
 }
 ```
 
@@ -273,7 +273,7 @@ dependencies {
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-routing-popup</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -281,7 +281,7 @@ dependencies {
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-routing-popup:0.6.3")
+    implementation("one.jpro.platform:jpro-routing-popup:0.7.1")
 }
 ```
 
@@ -295,7 +295,7 @@ applications.
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-mdfx</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -303,7 +303,7 @@ applications.
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-mdfx:0.6.3")
+    implementation("one.jpro.platform:jpro-mdfx:0.7.1")
 }
 ```
 
@@ -318,7 +318,7 @@ This data is only accessible in the JPro Server, not in the browser - which can 
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-session</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -326,7 +326,7 @@ This data is only accessible in the JPro Server, not in the browser - which can 
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-session:0.6.3")
+    implementation("one.jpro.platform:jpro-session:0.7.1")
 }
 ```
 
@@ -339,7 +339,7 @@ This library offers essential tools for various functionalities to enhance the d
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-utils</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependency>
 ```
@@ -347,7 +347,7 @@ This library offers essential tools for various functionalities to enhance the d
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation 'one.jpro.platform:jpro-utils:0.6.3'
+    implementation 'one.jpro.platform:jpro-utils:0.7.1'
 }
 ```
 
@@ -368,7 +368,7 @@ capabilities.
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-webrtc</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -376,7 +376,7 @@ capabilities.
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-webrtc:0.6.3")
+    implementation("one.jpro.platform:jpro-webrtc:0.7.1")
 }
 ```
 
@@ -391,7 +391,7 @@ the embedded controls. The video can be played in full-screen mode.
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-youtube</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -399,7 +399,7 @@ the embedded controls. The video can be played in full-screen mode.
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-youtube:0.6.3")
+    implementation("one.jpro.platform:jpro-youtube:0.7.1")
 }
 ```
 
@@ -428,7 +428,7 @@ Reactive dynamic CSS for JavaFX scenes and parents. Apply CSS strings at runtime
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-dynamic-css</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -436,7 +436,7 @@ Reactive dynamic CSS for JavaFX scenes and parents. Apply CSS strings at runtime
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-dynamic-css:0.6.3")
+    implementation("one.jpro.platform:jpro-dynamic-css:0.7.1")
 }
 ```
 
@@ -451,7 +451,7 @@ properties — all styleable via CSS.
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-flexbox</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -459,7 +459,7 @@ properties — all styleable via CSS.
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-flexbox:0.6.3")
+    implementation("one.jpro.platform:jpro-flexbox:0.7.1")
 }
 ```
 
@@ -472,7 +472,7 @@ Provides a skin implementation of a scrollpane for **JPro** applications only.
   <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-html-scrollpane</artifactId>
-    <version>0.6.3</version>
+    <version>0.7.1</version>
   </dependency>
 </dependencies>
 ```
@@ -480,7 +480,7 @@ Provides a skin implementation of a scrollpane for **JPro** applications only.
 #### Gradle configuration
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-html-scrollpane:0.6.3")
+    implementation("one.jpro.platform:jpro-html-scrollpane:0.7.1")
 }
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,8 +19,9 @@ The derived version is printed at the start of every build.
 The first argument is the project name, guarding against running this in the wrong repo.
 
 The script only tags: it verifies a clean tree on an up-to-date `main` and a dated
-`### 0.7.0` CHANGELOG entry, then tags and pushes `0.7.0`. The tag push triggers
-`.github/workflows/release.yml`, which builds and publishes via the scripts:
+`### 0.7.0` CHANGELOG entry, and that all README version pins already match `0.7.0`,
+then tags and pushes `0.7.0`. The tag push triggers `.github/workflows/release.yml`,
+which builds and publishes via the scripts:
 
 | Script | Registry | Versions |
 |---|---|---|
@@ -39,6 +40,6 @@ become `X.Y.(Z+1)-SNAPSHOT`.
 ## Notes
 
 - Transition: the latest existing tag is `0.6.3`, so until the first `0.7.0` tag exists, builds derive `0.6.4-SNAPSHOT` even though the next release is `0.7.0`. The first `./tagRelease.sh jpro-platform 0.7.0` realigns everything.
-- To release `0.7.0`: set the date on the `### 0.7.0` CHANGELOG entry (remove `(unreleased)`), commit, then `./tagRelease.sh jpro-platform 0.7.0`.
+- To release `0.7.0`: set the date on the `### 0.7.0` CHANGELOG entry (remove `(unreleased)`), run `./syncReadmeVersions.sh 0.7.0` to update the README version pins, commit, then `./tagRelease.sh jpro-platform 0.7.0`. The READMEs are published as `DOCUMENTATION` artifacts, so their pins are kept in sync with each release.
 - CI checkouts use `fetch-depth: 0` (configured) — a shallow clone can't see tags and would fall back to the SNAPSHOT default.
 - Set `MAVEN_CENTRAL_PUBLISHING_TYPE=USER_MANAGED` to review the deployment in the portal before it goes live; default is `AUTOMATIC`.

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ tasks.register('combineDocumentation') {
 
 def subprojectsWithDocs = [
         "jpro-auth",
+        "jpro-auth/routing",
         "jpro-dynamic-css",
         "jpro-file",
         "jpro-mail",

--- a/jpro-auth/README.md
+++ b/jpro-auth/README.md
@@ -101,7 +101,7 @@ processes. Add the following configuration to your project based on the build to
 - Gradle
     ```groovy
     dependencies {
-          implementation("one.jpro.platform:jpro-auth:0.6.3")
+          implementation("one.jpro.platform:jpro-auth-core:0.7.1")
     }
     ```
 - Maven
@@ -110,7 +110,7 @@ processes. Add the following configuration to your project based on the build to
       <dependency>
         <groupId>one.jpro.platform</groupId>
         <artifactId>jpro-auth-core</artifactId>
-        <version>0.6.3</version>
+        <version>0.7.1</version>
       </dependency>
     </dependencies>
     ```
@@ -121,7 +121,7 @@ the authentication process. Add the following configuration to your project base
 - Gradle
     ```groovy
     dependencies {
-          implementation("one.jpro.platform:jpro-auth-routing:0.6.3")
+          implementation("one.jpro.platform:jpro-auth-routing:0.7.1")
     }
     ```
 - Maven
@@ -130,7 +130,7 @@ the authentication process. Add the following configuration to your project base
       <dependency>
         <groupId>one.jpro.platform</groupId>
         <artifactId>jpro-auth-routing</artifactId>
-        <version>0.6.3</version>
+        <version>0.7.1</version>
       </dependency>
     </dependencies>
     ```
@@ -167,75 +167,91 @@ so there is no need to add it explicitly.
     ```
   
 ### Combined with the Routing API
-By simply adding the `jpro-auth-routing` dependency to your project, the authentication process can be simplified even 
-further resulting in a more concise and readable code. The following example shows how to authenticate a user with a 
-username and password using the `BasicAuthenticationProvider` in combination with `UsernamePasswordCredentials` class
-and the `AuthFilter` class provided by this module.
+Adding the `jpro-auth-routing` dependency lets you wire authentication into a `RouteApp` with a
+single route filter. The module provides:
+
+- `UserSession` — stores the logged-in `User` in the JPro session.
+- `AuthUIProviders` — factories for the login UI (`createGoogle`, `createOAuth2`, `createBasicProvider`, `combine`).
+- `AuthBasicFilter` — route filter for username/password authentication.
+- `AuthBasicOAuth2Filter` — route filter for OAuth2/OpenID authentication.
+
+> The full reference for these classes lives in the [`jpro-auth-routing` README](routing/README.md).
+
+**Username/password** with `BasicAuthenticationProvider` and `AuthBasicFilter`:
 
 ```java
-public class BasicAuthExample extends RouteApp {
-    
-    // Create a basic AuthenticationProvider with a single role "USER"
-    BasicAuthenticationProvider basicAuthProvider = AuthAPI.basicAuth()
-            .roles(Set.of("USER"))
-            .create();
+public class BasicLoginApp extends RouteApp {
 
-    // Username and Password Credentials holds the username and password
-    UsernamePasswordCredentials credentials = new UsernamePasswordCredentials();
-    
+    private final UserManager userManager = new InMemoryUserManager();
+    private final BasicAuthenticationProvider basicAuthProvider = AuthAPI.basicAuth()
+            .userManager(userManager)
+            .roles("USER", "ADMIN")
+            .create();
+    private final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials();
+
+    private static final SessionManager sessionManager = new SessionManager("basic-login-app");
+    private UserSession userSession;
+
     @Override
     public Route createRoute() {
+        var session = WebAPI.isBrowser() ? sessionManager.getSession(getWebAPI())
+                                         : sessionManager.getSession("user-session");
+        userSession = new UserSession(session);
+        var authUIProvider = AuthUIProviders.createBasicProvider(basicAuthProvider, userSession);
+
         return Route.empty()
-                .and(Route.get("/", request -> Response.node(new LoginPage(this, basicAuthProvider, credentials))))
-                .when(request -> isUserAuthenticated(), Route.empty()
+                .and(Route.get("/", request -> userSession.isLoggedIn()
+                        ? Response.redirect("/user/signed-in")
+                        : Response.node(authUIProvider.createAuthenticationNode())))
+                .when(request -> userSession.isLoggedIn(), Route.empty()
                         .and(Route.get("/user/signed-in", request -> Response.node(new SignedInPage(this)))))
-                .transform(AuthFilter.create(basicAuthProvider, credentials, user -> {
-                    setUser(user);
-                    return Response.redirect("/user/signed-in");
-                }, error -> Response.node(new ErrorPage(error))));
+                .transform(AuthBasicFilter.create(basicAuthProvider, credentials,
+                        user -> {
+                            userSession.setUser(user);
+                            return Response.redirect("/user/signed-in");
+                        },
+                        error -> Response.node(new ErrorPage(error))));
     }
 }
 ```
 
-Another example shows how to authenticate a user with an OAuth2 provider using the `GoogleAuthenticationProvider` in
-combination with the `OAuth2Filter` class provided by this module.
+**OAuth2 (Google)** with `AuthUIProviders.createGoogle` and `AuthBasicOAuth2Filter`:
 
 ```java
-public class OAuth2Example extends RouteApp {
-    
+public class GoogleLoginApp extends RouteApp {
+
+    private static final SessionManager sessionManager = new SessionManager("google-login-app");
+    private UserSession userSession;
+
     @Override
     public Route createRoute() {
-        // Create an OAuth2 AuthenticationProvider for Google
-        GoogleAuthenticationProvider googleAuthProvider = AuthAPI.googleAuth()
+        var session = WebAPI.isBrowser() ? sessionManager.getSession(getWebAPI())
+                                         : sessionManager.getSession("user-session");
+        userSession = new UserSession(session);
+
+        var googleAuthProvider = AuthAPI.googleAuth()
                 .clientId("your-client-id")
                 .clientSecret("your-client-secret")
+                .redirectUri("/auth/google")
                 .create(getStage());
-        
-        return Route.empty()
-                .and(Route.get("/", request -> Response.node(new LoginPage(googleAuthProvider))))
-                .when(request -> isUserAuthenticated(), Route.empty()
-                        .and(Route.get("/user/signed-in", request -> Response.node(new SignedInPage(this, googleAuthProvider)))))
-                .transform(OAuth2Filter.create(googleAuthProvider, user -> {
-                    setUser(user);
-                    return Response.redirect("/user/signed-in");
-                }, error -> Response.node(new ErrorPage(error))));
-    }
-}
-```
-Inside the `LoginPage` class, the `googleAuthProvider` is used to create a login button that redirects the user to the
-Google's login page.
 
-```java
-public class LoginPage extends VBox {
-    
-    public LoginPage(GoogleAuthenticationProvider googleAuthProvider) {
-        Button loginButton = new Button("Login with Google");
-        googleProviderButton.setOnAction(event -> OAuth2Filter.authorize(loginButton, googleAuthProvider));
-        
-        getChildren().add(loginButton);
+        // Renders a "Sign in with Google" button that starts the OAuth2 flow.
+        var uiProvider = AuthUIProviders.createGoogle(googleAuthProvider, userSession);
+
+        return Route.empty()
+                .and(Route.get("/", request -> Response.node(uiProvider.createAuthenticationNode())))
+                .when(request -> userSession.isLoggedIn(), Route.empty()
+                        .and(Route.get("/user/signed-in", request -> Response.node(new SignedInPage(this)))))
+                .transform(AuthBasicOAuth2Filter.create(googleAuthProvider, userSession,
+                        user -> Response.redirect("/user/signed-in"),
+                        error -> Response.node(new ErrorPage(error))));
     }
 }
 ```
+
+The OAuth2 filter matches the provider's `redirectUri` (here `/auth/google`), exchanges the
+authorization code for tokens, stores the resulting `User` in the `UserSession`, and then runs
+your success/error callback.
 
 
 ### Launch the examples

--- a/jpro-auth/routing/README.md
+++ b/jpro-auth/routing/README.md
@@ -1,0 +1,175 @@
+# JPro Auth Routing
+
+`jpro-auth-routing` combines [`jpro-auth-core`](../README.md) with
+[`jpro-routing`](../../jpro-routing/README.md), so authentication can be wired into a `RouteApp`
+as a single route filter. It adds the login UI, the session storage, and the route filters that
+handle the authentication callback.
+
+## Dependency
+
+```groovy
+dependencies {
+    implementation("one.jpro.platform:jpro-auth-routing:0.7.1")
+}
+```
+
+`jpro-auth-core` is pulled in transitively, so you don't need to add it explicitly.
+
+## Concepts
+
+| Type | Purpose |
+|---|---|
+| `UserSession` | Stores the authenticated `User` in the JPro session (as JSON under the key `"user"`). |
+| `AuthUIProvider` | An authentication method: a UI node (`createAuthenticationNode()`) plus a route filter (`createFilter()`). |
+| `AuthUIProviders` | Factories for ready-made providers (`createGoogle`, `createOAuth2`, `createBasicProvider`, `combine`). |
+| `AuthBasicFilter` | Route filter for username/password authentication. |
+| `AuthBasicOAuth2Filter` | Route filter for OAuth2 / OpenID authentication. |
+| `AuthRestrictionFilter` | Makes an entire route subtree accessible only to authenticated users. |
+| `GoogleLoginButton` | A `Button` pre-styled with Google's "Sign in with Google" branding. |
+
+## UserSession
+
+`UserSession` wraps the routing session map and is the single source of truth for "who is logged
+in". Create it once in `createRoute()` from the `SessionManager`, choosing the browser or desktop
+session depending on the runtime:
+
+```java
+var session = WebAPI.isBrowser() ? sessionManager.getSession(getWebAPI())
+                                 : sessionManager.getSession("user-session");
+UserSession userSession = new UserSession(session);
+
+userSession.setUser(user);   // store after a successful login
+userSession.getUser();       // null when not logged in
+userSession.isLoggedIn();    // convenience for getUser() != null
+userSession.logout();        // clears the stored user
+```
+
+The filters below call `setUser(...)` for you; you typically only call `getUser()`/`isLoggedIn()`
+when building routes and `logout()` from a sign-out action.
+
+## Login UI: AuthUIProviders
+
+An `AuthUIProvider` bundles the login UI with the matching filter. Use the factories:
+
+```java
+// Google "Sign in with Google" button
+AuthUIProvider google = AuthUIProviders.createGoogle(openidAuthProvider, userSession);
+
+// Generic OAuth2/OpenID, default "Login" button
+AuthUIProvider oauth2 = AuthUIProviders.createOAuth2(openidAuthProvider, userSession);
+
+// Generic OAuth2/OpenID with a custom button
+AuthUIProvider oauth2custom =
+        AuthUIProviders.createOAuth2(openidAuthProvider, userSession, () -> new Button("Sign in"));
+
+// Username/password form (text fields + login button)
+AuthUIProvider basic = AuthUIProviders.createBasicProvider(basicAuthProvider, userSession);
+
+// Offer several methods on one page
+AuthUIProvider combined = AuthUIProviders.combine(google, basic);
+```
+
+Render the UI with `provider.createAuthenticationNode()`.
+
+> Note: `createBasicProvider` performs the login inside its UI node (it calls `authenticate` and
+> `userSession.setUser(...)` directly), so its `createFilter()` returns `Transformer.empty()`. The
+> OAuth2 providers, by contrast, rely on a redirect callback and therefore need their filter
+> applied to the route (see below).
+
+## Route filters
+
+### AuthBasicFilter
+
+```java
+static Transformer create(BasicAuthenticationProvider authProvider,
+                          UsernamePasswordCredentials credentials,
+                          Function<User, Response> onSuccess,
+                          Function<Throwable, Response> onError)
+
+static void authorize(Node node, BasicAuthenticationProvider basicAuthProvider)
+```
+
+`create(...)` returns a filter that triggers when the request path equals the provider's
+`getAuthorizationPath()`. It authenticates the `credentials`, then runs `onSuccess`/`onError`.
+`authorize(node, provider)` navigates to that authorization path (e.g. from a button action).
+
+### AuthBasicOAuth2Filter
+
+```java
+// 1. OpenID provider, no session storage
+static Transformer create(OpenIDAuthenticationProvider openidAuthProvider,
+                          Function<User, Response> onSuccess,
+                          Function<Throwable, Response> onError)
+
+// 2. OpenID provider, store user in session (recommended)
+static Transformer create(OpenIDAuthenticationProvider openidAuthProvider,
+                          UserSession userSession,
+                          Function<User, Response> onSuccess,
+                          Function<Throwable, Response> onError)
+
+// 3. Full control: explicit provider, optional session, explicit credentials
+static Transformer create(OAuth2AuthenticationProvider authProvider,
+                          @Nullable UserSession userSession,
+                          OAuth2Credentials credentials,
+                          Function<User, Response> onSuccess,
+                          Function<Throwable, Response> onError)
+
+// Start the flow from a UI node:
+static void authorize(Node node, OpenIDAuthenticationProvider openidAuthProvider)
+static void authorize(Node node, OAuth2AuthenticationProvider authProvider, OAuth2Credentials credentials)
+```
+
+The `create(...)` filter triggers when the request matches the credentials' `redirectUri`
+(via `Request.matchesSoft`). It exchanges the authorization code for tokens, stores the resulting
+`User` in the `UserSession` (when one is given), and runs your `onSuccess`/`onError` callback.
+
+`authorize(...)` builds the provider's authorization URL and starts the flow. In the browser JPro
+redirects automatically; on the desktop it calls `gotoURL(...)` so the route reaches the redirect
+URI. Overloads 1/2 take the provider's pre-configured credentials; overload with explicit
+`OAuth2Credentials` is for advanced cases.
+
+### AuthRestrictionFilter
+
+```java
+static Transformer create(AuthUIProvider authProvider, UserSession userSession)
+```
+
+Wraps a route so that unauthenticated users see `authProvider.createAuthenticationNode()` instead
+of the protected content; authenticated users pass through.
+
+## Example: OAuth2 with Google
+
+```java
+public class GoogleLoginApp extends RouteApp {
+
+    private static final SessionManager sessionManager = new SessionManager("google-login-app");
+    private UserSession userSession;
+
+    @Override
+    public Route createRoute() {
+        var session = WebAPI.isBrowser() ? sessionManager.getSession(getWebAPI())
+                                         : sessionManager.getSession("user-session");
+        userSession = new UserSession(session);
+
+        var googleAuthProvider = AuthAPI.googleAuth()
+                .clientId("your-client-id")
+                .clientSecret("your-client-secret")
+                .redirectUri("/auth/google")
+                .create(getStage());
+
+        var uiProvider = AuthUIProviders.createGoogle(googleAuthProvider, userSession);
+
+        return Route.empty()
+                .and(Route.get("/", request -> Response.node(uiProvider.createAuthenticationNode())))
+                .when(request -> userSession.isLoggedIn(), Route.empty()
+                        .and(Route.get("/user/signed-in", request -> Response.node(new SignedInPage(this)))))
+                .transform(AuthBasicOAuth2Filter.create(googleAuthProvider, userSession,
+                        user -> Response.redirect("/user/signed-in"),
+                        error -> Response.node(new ErrorPage(error))));
+    }
+}
+```
+
+You can register several OAuth2 providers (Google, Microsoft, Keycloak) by applying one
+`AuthBasicOAuth2Filter.create(...)` transform per provider, each matching its own `redirectUri`.
+See the `jpro-auth/example` module for runnable samples.

--- a/jpro-auth/routing/build.gradle
+++ b/jpro-auth/routing/build.gradle
@@ -7,6 +7,12 @@ dependencies {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            // Add README.md as an artifact named DOCUMENTATION.md
+            artifact(source: file('build/docs/DOCUMENTATION.md')) {
+                classifier 'DOCUMENTATION'
+                extension 'md'
+            }
+
             pom {
                 name = 'JPro Auth Routing'
                 description = 'A module that makes it easy to combine and use the authentication and routing functionalities.'
@@ -14,3 +20,11 @@ publishing {
         }
     }
 }
+
+tasks.register('renameReadme', Copy) {
+    from 'README.md'
+    into layout.buildDirectory.dir('docs')
+    rename 'README.md', 'DOCUMENTATION.md'
+}
+
+javadocJar.dependsOn renameReadme

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthRestrictionFilter.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthRestrictionFilter.java
@@ -12,7 +12,6 @@ public class AuthRestrictionFilter {
                                                  @NotNull UserSession userSession) {
         var filter = routingAuthenticationProvider.createFilter();
         Transformer result1 = (route) -> (request) -> {
-            System.out.println("Got user: " + userSession.getUser());
             if (userSession.getUser() != null) {
                 return route.apply(request);
             } else {

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProvider.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProvider.java
@@ -4,12 +4,25 @@ import javafx.scene.Node;
 import one.jpro.platform.routing.Transformer;
 
 /**
- * This class represents an Authentication Method, represented by:
- * 1. A Node that can be used to display the authentication UI.
- * 2. A Transformer that can be used to integrate the authentication method
- *   into theo RouteApp.
+ * Represents an authentication method, made up of two parts:
+ * <ol>
+ *   <li>A {@link Node} that displays the authentication UI (e.g. a login button or form).</li>
+ *   <li>A {@link Transformer} that integrates the authentication method into the {@code RouteApp}.</li>
+ * </ol>
  */
 public interface AuthUIProvider {
+
+    /**
+     * Creates the JavaFX node that renders the authentication UI (e.g. a login button or form).
+     *
+     * @return the authentication UI node
+     */
     Node createAuthenticationNode();
+
+    /**
+     * Creates the route filter that handles the authentication callback for this method.
+     *
+     * @return a {@link Transformer} to apply to the application route
+     */
     Transformer createFilter();
 }

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProviders.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProviders.java
@@ -118,14 +118,24 @@ public class AuthUIProviders {
     }
 
     /**
-     * Combines multiple AuthUIProviders into a single AuthUIProvider.
+     * Combines multiple {@link AuthUIProvider}s into one, stacking their authentication
+     * nodes in a {@link VBox} and composing their filters. Lets an application offer
+     * several login methods (e.g. Google and basic) on the same page.
+     *
+     * @param providers the providers to combine
+     * @return a single provider that renders and filters all of them
      */
     public static AuthUIProvider combine(AuthUIProvider... providers) {
         return combine(() -> new VBox(), providers);
     }
 
     /**
+     * Combines multiple {@link AuthUIProvider}s into one, using the given pane as the
+     * layout for their authentication nodes and composing their filters.
      *
+     * @param paneSupplier supplies the pane that hosts the authentication nodes
+     * @param providers    the providers to combine
+     * @return a single provider that renders and filters all of them
      */
     public static AuthUIProvider combine(Supplier<Pane> paneSupplier, AuthUIProvider... providers) {
         return new AuthUIProvider() {

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/buttons/GoogleLoginButton.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/buttons/GoogleLoginButton.java
@@ -1,14 +1,14 @@
 package one.jpro.platform.auth.routing.buttons;
 
 import javafx.scene.control.Button;
-import javafx.scene.image.Image;
 
-import java.net.URL;
-
+/**
+ * A {@link Button} pre-styled with Google's official "Sign in with Google" branding,
+ * sized 175x40. Used by {@code AuthUIProviders.createGoogle(...)}.
+ */
 public class GoogleLoginButton extends Button {
 
     public GoogleLoginButton() {
-
         setStyle("-fx-background-color: transparent; " +
                 "-fx-background-image: url(/one/jpro/platform/auth/routing/buttons/google/web_light_sq_SI@2x.png);" +
                 "-fx-background-size: cover;" +

--- a/jpro-dynamic-css/README.md
+++ b/jpro-dynamic-css/README.md
@@ -8,7 +8,7 @@ Apply CSS strings to JavaFX scenes and parents at runtime. Each call replaces th
 
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-dynamic-css:0.6.0-SNAPSHOT")
+    implementation("one.jpro.platform:jpro-dynamic-css:0.7.1")
 }
 ```
 
@@ -18,7 +18,7 @@ dependencies {
 <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-dynamic-css</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.7.1</version>
 </dependency>
 ```
 

--- a/jpro-file/README.md
+++ b/jpro-file/README.md
@@ -88,7 +88,7 @@ Add the following configuration to your project based on the build tool you are 
 - Gradle
     ```groovy
     dependencies {
-        implementation("one.jpro.platform:jpro-file:0.6.3")
+        implementation("one.jpro.platform:jpro-file:0.7.1")
     }
     ```
 - Maven
@@ -97,7 +97,7 @@ Add the following configuration to your project based on the build tool you are 
       <dependency>
         <groupId>one.jpro.platform</groupId>
         <artifactId>jpro-file</artifactId>
-        <version>0.6.3</version>
+        <version>0.7.1</version>
       </dependency>
     </dependencies>
     ```

--- a/jpro-flexbox/README.md
+++ b/jpro-flexbox/README.md
@@ -8,7 +8,7 @@ A CSS FlexBox layout implementation for JavaFX. All properties are styleable via
 
 ```groovy
 dependencies {
-    implementation("one.jpro.platform:jpro-flexbox:0.6.0-SNAPSHOT")
+    implementation("one.jpro.platform:jpro-flexbox:0.7.1")
 }
 ```
 
@@ -18,7 +18,7 @@ dependencies {
 <dependency>
     <groupId>one.jpro.platform</groupId>
     <artifactId>jpro-flexbox</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.7.1</version>
 </dependency>
 ```
 

--- a/jpro-mail/README.md
+++ b/jpro-mail/README.md
@@ -59,7 +59,7 @@ email attributes such as sender, recipients, subject, and date, as well as metho
 - Gradle
     ```groovy
     dependencies {
-        implementation("one.jpro.platform:jpro-mail:0.6.3")
+        implementation("one.jpro.platform:jpro-mail:0.7.1")
     }
     ```
 - Maven
@@ -68,7 +68,7 @@ email attributes such as sender, recipients, subject, and date, as well as metho
       <dependency>
         <groupId>one.jpro.platform</groupId>
         <artifactId>jpro-mail</artifactId>
-        <version>0.6.3</version>
+        <version>0.7.1</version>
       </dependency>
     </dependencies>
     ```

--- a/jpro-media/README.md
+++ b/jpro-media/README.md
@@ -37,7 +37,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'one.jpro.platform:jpro-media:0.6.3'
+    implementation 'one.jpro.platform:jpro-media:0.7.1'
 
     // use compileOnly configuration when running/deploying with JPro, 
     // since the platform specific libraries are no more needed
@@ -72,7 +72,7 @@ the `release` zipped file. Even the `jpro:run` task is faster since these files 
     <dependency>
         <groupId>one.jpro.platform</groupId>
         <artifactId>jpro-media</artifactId>
-        <version>0.6.3</version>
+        <version>0.7.1</version>
     </dependency>
     <dependency>
         <groupId>org.bytedeco</groupId>

--- a/jpro-routing/README.md
+++ b/jpro-routing/README.md
@@ -116,9 +116,9 @@ String           request.getPath()
 String           request.getDomain()
 String           request.getProtocol()
 int              request.getPort()
-Optional<String> request.getQueryParameter(String name)     // Scala Option
-String           request.getQueryParameterOrElse(String name, String default)
-Map<String,String> request.getQueryParameters()
+Optional<String>     request.getQueryParameter(String name)   // java.util.Optional
+String               request.getQueryParameterOrElse(String name, String default)
+java.util.Map<String,String> request.getQueryParameters()
 ```
 
 ### Setting Links

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Page.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Page.scala
@@ -8,22 +8,34 @@ object Page {
   def fromNode(node: javafx.scene.Node): Page = RouteUtils.pageFromNode(node)
 }
 abstract class Page extends ResponseResult { THIS =>
+  /** The page title; used for the browser tab and for SEO. May be `null`. */
   def title: String
+  /** The page description; used for SEO and by the `AppCrawler`. */
   def description: String
+  /** The URL this page was created for; set by the router. May be `null` before routing. */
   var url: String = null
+  /** Whether the page is rendered for a mobile client; set by the router. */
   var isMobile: Boolean = false
 
   private var sessionManager: SessionManager = null
+  /** Returns the [[SessionManager]] for this page, or `null` if it has not been set yet. */
   def getSessionManager(): SessionManager = sessionManager
+  /** Sets the [[SessionManager]] for this page (normally called by the router). */
   def setSessionManager(x: SessionManager): Unit = {
     sessionManager = x
   }
 
+  /** The page content node, computed once from [[content]] and cached. */
   lazy val realContent: Node = content
+  /** Builds the page's content node. Implement this to provide the page UI. */
   protected def content: Node
+  /** Whether the scroll position should be saved and restored when navigating back. */
   def saveScrollPosition = true
+  /** Whether the page fills the whole area (true) or is scrollable (false). Override to change. */
   def fullscreen = false
+  /** Called when the user navigates away from this page. Override to release resources. */
   def onClose(): Unit = {}
+  /** The currently active sub-page, or `null` if there is none. */
   def subPage(): Page = null
 
   override def toString: String = s"Page(title: $title, url: $url, description: $description)"

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Request.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/Request.scala
@@ -6,7 +6,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import java.lang.ref.WeakReference
 import java.net.URI
-import java.util.{Map => JMap}
+import java.util.{Map => JMap, Optional}
 
 /**
  * An incoming request, carrying the parsed URL (protocol, domain, port, path,
@@ -43,8 +43,10 @@ case class Request (
   def getPath(): String = path
   /** Returns the directory this request is mounted at, "/" by default. */
   def getDirectory(): String = directory
-  /** Returns the query parameter, or an empty Option when absent. */
-  def getQueryParameter(key: String): Option[String] = queryParameters.get(key)
+  /** Returns the query parameter, or an empty {@link Optional} when absent. */
+  def getQueryParameter(key: String): Optional[String] = Optional.ofNullable(queryParameters.getOrElse(key, null))
+  /** Scala variant of {@link getQueryParameter}, returning a Scala {@code Option}. */
+  def getQueryParameterScala(key: String): Option[String] = queryParameters.get(key)
   /** Returns the query parameter, or the default when absent. */
   def getQueryParameterOrElse(key: String, default: String): String = queryParameters.getOrElse(key, default)
 

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/RouteUtils.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/RouteUtils.scala
@@ -9,6 +9,12 @@ import java.util.function.Function
 
 object RouteUtils {
 
+  /**
+   * A [[Transformer]] that fades from the previous page to the new one over `seconds` seconds.
+   * Apply it with `route.transform(RouteUtils.transition(0.5))`.
+   *
+   * @param seconds duration of the fade
+   */
   def transition(seconds: Double): Transformer = route => { request => {
     Response(route.apply(request).future.map{
       case x: Page =>
@@ -29,6 +35,12 @@ object RouteUtils {
       case x => x
     })
   }}
+  /**
+   * A [[Transformer]] that slides the new page in from the side while the previous page slides
+   * out, over `seconds` seconds. Apply it with `route.transform(RouteUtils.sideTransition(0.5))`.
+   *
+   * @param seconds duration of the slide
+   */
   def sideTransition(seconds: Double): Transformer = route => { request => {
     Response(route.apply(request).future.map{
       case x: Page =>
@@ -59,6 +71,7 @@ object RouteUtils {
     })
   }}
 
+  /** Wraps a plain JavaFX `Node` in a minimal [[Page]] (no title, empty description). */
   def pageFromNode(x: Node): Page = new Page {
     override def title: String = null
     override def description: String = ""

--- a/jpro-routing/core/src/main/scala/one/jpro/platform/routing/container/Container.scala
+++ b/jpro-routing/core/src/main/scala/one/jpro/platform/routing/container/Container.scala
@@ -3,14 +3,26 @@ package one.jpro.platform.routing.container
 import javafx.beans.property.ObjectProperty
 import one.jpro.platform.routing.Request
 
+/**
+ * A persistent wrapper around the changing page content (e.g. a menu, header or footer that
+ * stays in place while the routed page changes). Implement this on a `Node` and apply it with
+ * `ContainerTransformer.fromContainer(...)`. The router sets the current page via `contentProperty`
+ * and the current request via `requestProperty`; the container reads them to render itself.
+ */
 trait Container {
 
+  /** The property holding the current page content; the router updates it on navigation. */
   def contentProperty(): ObjectProperty[javafx.scene.Node]
+  /** Returns the current page content. */
   def getContent(): javafx.scene.Node = contentProperty().get()
+  /** Sets the current page content (normally called by the router). */
   def setContent(x: javafx.scene.Node): Unit = contentProperty().set(x)
 
+  /** The property holding the current request; the router updates it on navigation. */
   def requestProperty(): ObjectProperty[Request]
+  /** Returns the current request. */
   def getRequest(): Request = requestProperty().get()
+  /** Sets the current request (normally called by the router). */
   def setRequest(x: Request): Unit = requestProperty().set(x)
 
 }

--- a/syncReadmeVersions.sh
+++ b/syncReadmeVersions.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Rewrites (or, with --check, validates) the one.jpro.platform version pins in every
+# README.md so the published documentation stays in sync with the release. See RELEASING.md.
+#
+#   ./syncReadmeVersions.sh X.Y.Z            rewrite all pins to X.Y.Z
+#   ./syncReadmeVersions.sh --check X.Y.Z    list pins that differ from X.Y.Z (exit 1 if any)
+set -e
+
+CHECK=0
+if [ "$1" = "--check" ]; then
+    CHECK=1
+    shift
+fi
+
+VERSION=$1
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "usage: ./syncReadmeVersions.sh [--check] X.Y.Z"
+    exit 1
+fi
+
+cd "$(dirname "$0")"
+READMES=$(git ls-files '*README.md')
+
+if [ "$CHECK" = "1" ]; then
+    STALE=$(VERSION="$VERSION" perl -0777 -ne '
+      my $v = $ENV{VERSION};
+      while (/one\.jpro\.platform:[A-Za-z0-9_.-]+:([0-9]+\.[0-9]+\.[0-9]+(?:-SNAPSHOT)?)/g) {
+        print "$ARGV: $1\n" if $1 ne $v;
+      }
+      while (/<groupId>\s*one\.jpro\.platform\s*<\/groupId>\s*<artifactId>[^<]+<\/artifactId>\s*<version>([0-9]+\.[0-9]+\.[0-9]+(?:-SNAPSHOT)?)<\/version>/sg) {
+        print "$ARGV: $1\n" if $1 ne $v;
+      }
+    ' $READMES)
+    if [ -n "$STALE" ]; then
+        echo "$STALE"
+        exit 1
+    fi
+    exit 0
+fi
+
+VERSION="$VERSION" perl -0777 -i -pe '
+  my $v = $ENV{VERSION};
+  s/(one\.jpro\.platform:[A-Za-z0-9_.-]+:)[0-9]+\.[0-9]+\.[0-9]+(?:-SNAPSHOT)?/${1}$v/g;
+  s/(<groupId>\s*one\.jpro\.platform\s*<\/groupId>\s*<artifactId>[^<]+<\/artifactId>\s*<version>)[0-9]+\.[0-9]+\.[0-9]+(?:-SNAPSHOT)?(<\/version>)/${1}$v${2}/gs;
+' $READMES
+echo "Updated README.md version pins to $VERSION."

--- a/tagRelease.sh
+++ b/tagRelease.sh
@@ -48,6 +48,14 @@ if grep "^### $VERSION " CHANGELOG.md | grep -qi "unreleased"; then
     exit 1
 fi
 
+STALE_READMES=$(./syncReadmeVersions.sh --check "$VERSION") || true
+if [ -n "$STALE_READMES" ]; then
+    echo "error: README.md files pin one.jpro.platform versions that don't match $VERSION:"
+    echo "$STALE_READMES"
+    echo "run './syncReadmeVersions.sh $VERSION', commit, then re-run."
+    exit 1
+fi
+
 git tag "$VERSION"
 git push origin "$VERSION"
 echo "Tagged and pushed $VERSION — the release workflow takes it from here:"


### PR DESCRIPTION
Documentation and small API cleanups for the routing/auth modules.

**jpro-auth-routing**
- Rewrote the auth README's routing section to the real API (`AuthBasicFilter`/`AuthBasicOAuth2Filter`/`UserSession`/`AuthUIProviders`); the old `AuthFilter`/`OAuth2Filter` names never existed.
- Added a dedicated `jpro-auth/routing/README.md` and published it as the `DOCUMENTATION` classifier so the ai-docs plugin discovers the module.
- Removed a user-leaking `System.out.println`; added Javadoc and dropped dead imports.

**jpro-routing-core**
- `Request.getQueryParameter` now returns `java.util.Optional<String>` (Java-first); added a Scala-only `getQueryParameterScala`. No existing callers.
- Scaladoc for previously-undocumented `Page`/`Container`/`RouteUtils` members.

**Version sync**
- Normalized all README `one.jpro.platform` pins to `0.7.1` (were stale at `0.6.3`/`0.6.0-SNAPSHOT`).
- New `syncReadmeVersions.sh` (rewrite + `--check`); `tagRelease.sh` now fails the release if README pins don't match the release version. Documented in `RELEASING.md`.

Verified: `:jpro-routing:core:compileScala`, `:jpro-auth:routing:compileJava`, `:jpro-auth:example:compileJava` and `:jpro-routing:core-test:test` pass; `syncReadmeVersions.sh` round-trip tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)