### PR TITLE
Add READMEs + DOCUMENTATION publishing for 7 modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,11 @@ def subprojectsWithDocs = [
         "jpro-mdfx",
         "jpro-flexbox",
         "jpro-media",
-        "jpro-routing"
+        "jpro-routing",
+        "jpro-routing/dev",
+        "jpro-routing/popup",
+        "jpro-scenegraph",
+        "jpro-utils"
 ]
 
 tasks.register('combineDocumentationFull') {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ def subprojectsWithDocs = [
         "jpro-routing/dev",
         "jpro-routing/popup",
         "jpro-scenegraph",
+        "jpro-session",
+        "jpro-html-scrollpane",
+        "jpro-youtube",
         "jpro-utils"
 ]
 

--- a/jpro-html-scrollpane/README.md
+++ b/jpro-html-scrollpane/README.md
@@ -1,0 +1,36 @@
+# JPro HTML ScrollPane Skin
+
+> **Experimental / prototype.** This module is an early prototype — the API and behavior may change,
+> and it is not yet recommended for production use.
+
+`jpro-html-scrollpane` provides `HTMLScrollPaneSkin`, a custom skin for the JavaFX `ScrollPane` that,
+when running in the browser under JPro, scrolls its content using a native HTML scroll container
+instead of the JavaFX scrollbars. This gives smooth, native scrolling (including momentum/touch) for
+web deployments, while still working on the desktop.
+
+## Dependency
+
+```groovy
+dependencies {
+    implementation("one.jpro.platform:jpro-html-scrollpane:0.7.1")
+}
+```
+
+## Usage
+
+Apply the skin to a `ScrollPane`:
+
+```java
+ScrollPane scrollPane = new ScrollPane(content);
+scrollPane.setSkin(new HTMLScrollPaneSkin(scrollPane));
+```
+
+An optional second constructor argument passes extra attributes to the underlying HTML container:
+
+```java
+scrollPane.setSkin(new HTMLScrollPaneSkin(scrollPane, "additional-attributes"));
+```
+
+The skin tracks the scroll pane's visibility (via `jpro-utils` `TreeShowing`) and cleans up the
+embedded HTML view when the pane leaves the scene graph, avoiding the resource leaks that embedded
+web content can otherwise cause.

--- a/jpro-html-scrollpane/build.gradle
+++ b/jpro-html-scrollpane/build.gradle
@@ -8,6 +8,12 @@ dependencies {
 publishing {
   publications {
     mavenJava(MavenPublication) {
+      // Add README.md as an artifact named DOCUMENTATION.md
+      artifact(source: file('build/docs/DOCUMENTATION.md')) {
+        classifier 'DOCUMENTATION'
+        extension 'md'
+      }
+
       pom {
         name = 'JPro HTML Scrollpane Skin'
         description = 'A module containing a ScrollPane skin for HTML content'
@@ -15,3 +21,11 @@ publishing {
     }
   }
 }
+
+tasks.register('renameReadme', Copy) {
+  from 'README.md'
+  into layout.buildDirectory.dir('docs')
+  rename 'README.md', 'DOCUMENTATION.md'
+}
+
+javadocJar.dependsOn renameReadme

--- a/jpro-routing/build.gradle
+++ b/jpro-routing/build.gradle
@@ -74,6 +74,12 @@ configure([project(':jpro-routing:dev')]) {
     publishing {
         publications {
             mavenJava(MavenPublication) {
+                // Add README.md as an artifact named DOCUMENTATION.md
+                artifact(source: file('build/docs/DOCUMENTATION.md')) {
+                    classifier 'DOCUMENTATION'
+                    extension 'md'
+                }
+
                 pom {
                     name = 'JPro Routing Dev'
                     description = 'A module that provides extra routing tools useful during development.'
@@ -81,6 +87,14 @@ configure([project(':jpro-routing:dev')]) {
             }
         }
     }
+
+    tasks.register('renameReadme', Copy) {
+        from 'README.md'
+        into layout.buildDirectory.dir('docs')
+        rename 'README.md', 'DOCUMENTATION.md'
+    }
+
+    javadocJar.dependsOn renameReadme
 }
 
 configure([project(':jpro-routing:core-test')]) {

--- a/jpro-routing/dev/README.md
+++ b/jpro-routing/dev/README.md
@@ -1,0 +1,39 @@
+# JPro Routing Dev
+
+`jpro-routing-dev` provides development-time overlays for [JPro Routing](../README.md)
+applications. Apply them as transformers on your route and remove (or conditionally apply) them in
+production builds.
+
+## Dependency
+
+```groovy
+dependencies {
+    implementation("one.jpro.platform:jpro-routing-dev:0.7.1")
+}
+```
+
+## Usage
+
+```java
+route
+    .transform(DevTransformer.create())          // dev toolbar
+    .transform(StatisticsTransformer.create());  // live performance statistics (browser)
+```
+
+### DevTransformer
+
+`DevTransformer.create()` returns a `Transformer` that wraps every page with a development toolbar:
+
+- back / forward / refresh navigation and an editable URL bar,
+- a [ScenicView](https://github.com/JonathanGiles/scenic-view) launcher,
+- a "pages uncollected" counter (backed by JMemoryBuddy) and a force-GC button,
+- live CSS reloading via [CSSFX](https://github.com/McFoggy/cssfx).
+
+### StatisticsTransformer
+
+`StatisticsTransformer.create()` returns a `Transformer` that, when running in the browser, shows
+live statistics: latency, bytes sent/received, number of synchronized / created / collected nodes,
+and load times.
+
+> Both are intended for development only. Apply them conditionally (e.g. behind a debug flag) so
+> they don't ship in production.

--- a/jpro-routing/popup/README.md
+++ b/jpro-routing/popup/README.md
@@ -1,0 +1,50 @@
+# JPro Routing Popup
+
+`jpro-routing-popup` provides popups and loading overlays that work in [JPro Routing](../README.md)
+applications, on both desktop and in the browser.
+
+## Dependency
+
+```groovy
+dependencies {
+    implementation("one.jpro.platform:jpro-routing-popup:0.7.1")
+}
+```
+
+## Usage
+
+Add the popup container transformer once, at the end of your route definition. It installs the
+overlay layer that popups are rendered into:
+
+```java
+route.transform(PopupAPI.createPopupContainerTransformer());
+```
+
+Then, from anywhere in the scene graph (`node` is any node in the application):
+
+```java
+// open / close a popup
+PopupAPI.openPopup(node, SimplePopups.infoPopup("Info", "Saved successfully."));
+PopupAPI.closePopup(anyNodeInsidePopup);
+
+// show a loading overlay until a future completes
+FXFuture<Result> result = PopupAPI.showLoadingScreen(node, someFXFuture);
+```
+
+`openPopup` and `closePopup` locate the popup container by walking up from the given node, so the
+node must be attached to the application's scene graph.
+
+## API
+
+`PopupAPI`
+- `createPopupContainerTransformer()` — the route transformer that installs the overlay layer.
+- `openPopup(Node contextHolder, Node popup)` — show `popup` in the overlay.
+- `closePopup(Node anyNodeInPopup)` — close the popup containing the given node.
+- `showLoadingScreen(Node contextHolder, FXFuture<T> future)` — show a loading overlay until
+  `future` completes; returns the same future for chaining.
+- `registerPopupContainer(Pane container)` — register a custom container (advanced).
+
+`SimplePopup` — a prebuilt popup (`StackPane`) with a title bar, content area and button area;
+constructible directly via `new SimplePopup(title, content, buttons, closable)`.
+
+`SimplePopups` — factories for common cases, e.g. `infoPopup(String title, String infoText)`.

--- a/jpro-routing/popup/build.gradle
+++ b/jpro-routing/popup/build.gradle
@@ -9,6 +9,12 @@ dependencies {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            // Add README.md as an artifact named DOCUMENTATION.md
+            artifact(source: file('build/docs/DOCUMENTATION.md')) {
+                classifier 'DOCUMENTATION'
+                extension 'md'
+            }
+
             pom {
                 name = 'JPro Routing Popup'
                 description = 'A module that provides utility methods for managing popups in a JPro/JavaFX application.'
@@ -16,3 +22,11 @@ publishing {
         }
     }
 }
+
+tasks.register('renameReadme', Copy) {
+    from 'README.md'
+    into layout.buildDirectory.dir('docs')
+    rename 'README.md', 'DOCUMENTATION.md'
+}
+
+javadocJar.dependsOn renameReadme

--- a/jpro-scenegraph/README.md
+++ b/jpro-scenegraph/README.md
@@ -1,0 +1,29 @@
+# JPro Scenegraph
+
+`jpro-scenegraph` serializes a JavaFX scene graph into a compact string representation that is both
+human- and AI-readable. It is useful for debugging, logging, snapshot tests, or feeding a UI tree
+to an LLM.
+
+## Dependency
+
+```groovy
+dependencies {
+    implementation("one.jpro.platform:jpro-scenegraph:0.7.1")
+}
+```
+
+## Usage
+
+`SceneGraphSerializer.serialize(Node)` walks the node and its descendants and returns an indented
+text tree:
+
+```java
+import one.jpro.platform.scenegraph.SceneGraphSerializer;
+
+String tree = SceneGraphSerializer.serialize(myRootNode);
+System.out.println(tree);
+```
+
+Layout containers (`VBox`, `HBox`, `StackPane`, `GridPane`, `ScrollPane`) are rendered with their
+children nested by indentation; leaf controls such as `Label` and `Button` are rendered inline with
+their text. The method is static and side-effect free.

--- a/jpro-scenegraph/build.gradle
+++ b/jpro-scenegraph/build.gradle
@@ -1,6 +1,12 @@
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            // Add README.md as an artifact named DOCUMENTATION.md
+            artifact(source: file('build/docs/DOCUMENTATION.md')) {
+                classifier 'DOCUMENTATION'
+                extension 'md'
+            }
+
             pom {
                 name = 'JPro Scenegraph'
                 description = 'A module that serializes a scene graph to a string representation making it both ' +
@@ -9,3 +15,11 @@ publishing {
         }
     }
 }
+
+tasks.register('renameReadme', Copy) {
+    from 'README.md'
+    into layout.buildDirectory.dir('docs')
+    rename 'README.md', 'DOCUMENTATION.md'
+}
+
+javadocJar.dependsOn renameReadme

--- a/jpro-session/README.md
+++ b/jpro-session/README.md
@@ -1,0 +1,46 @@
+# JPro Session
+
+`jpro-session` provides a simple server-side session manager for JPro/JavaFX applications. A session
+is an `ObservableMap<String, String>` that persists across requests, keyed by a cookie in the
+browser or by an explicit key on the desktop.
+
+## Dependency
+
+```groovy
+dependencies {
+    implementation("one.jpro.platform:jpro-session:0.7.1")
+}
+```
+
+## Usage
+
+Create one `SessionManager` per application (the name namespaces the on-disk storage), then obtain
+the session — by `WebAPI` in the browser, or by an explicit key on the desktop:
+
+```java
+SessionManager sessionManager = new SessionManager("my-app");
+
+ObservableMap<String, String> session = WebAPI.isBrowser()
+        ? sessionManager.getSession(getWebAPI())     // browser: keyed by cookie
+        : sessionManager.getSession("user-session"); // desktop: explicit key
+
+session.put("user", userJson);
+String user = session.get("user");
+```
+
+Because the session is observable, you can listen for changes. `getSession(String)` must be called
+on the JavaFX Application Thread and throws `SessionException` otherwise.
+
+## API
+
+`SessionManager`
+- `SessionManager(String appName)` — store sessions under a per-app default directory.
+- `SessionManager(File baseDirectory, String cookieName)` — custom storage directory and cookie name.
+- `getSession(WebAPI webAPI)` — the session for the current browser client (cookie-based).
+- `getSession(String sessionKey)` — the session for an explicit key (desktop).
+- `getFolder()` — the base directory used for session storage.
+
+`SessionException` — thrown when the session directory can't be created or a session is accessed
+off the FX thread.
+
+> `jpro-auth-routing`'s `UserSession` is a thin wrapper around such a session map.

--- a/jpro-session/build.gradle
+++ b/jpro-session/build.gradle
@@ -9,6 +9,12 @@ dependencies {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            // Add README.md as an artifact named DOCUMENTATION.md
+            artifact(source: file('build/docs/DOCUMENTATION.md')) {
+                classifier 'DOCUMENTATION'
+                extension 'md'
+            }
+
             pom {
                 name = 'JPro Session'
                 description = 'A module that provides a simple implementation of a session manager for JavaFX/JPro applications.'
@@ -16,3 +22,11 @@ publishing {
         }
     }
 }
+
+tasks.register('renameReadme', Copy) {
+    from 'README.md'
+    into layout.buildDirectory.dir('docs')
+    rename 'README.md', 'DOCUMENTATION.md'
+}
+
+javadocJar.dependsOn renameReadme

--- a/jpro-utils/README.md
+++ b/jpro-utils/README.md
@@ -1,0 +1,93 @@
+# JPro Utils
+
+`jpro-utils` is a small collection of utilities for JPro/JavaFX applications that behave correctly
+both on the desktop and in the browser.
+
+## Dependency
+
+```groovy
+dependencies {
+    implementation("one.jpro.platform:jpro-utils:0.7.1")
+}
+```
+
+## What's inside
+
+### PlatformUtils
+
+Static platform checks for the desktop runtime:
+
+```java
+PlatformUtils.isDesktop();   // running on the JVM desktop (not in the browser)
+PlatformUtils.isWindows();
+PlatformUtils.isMac();
+PlatformUtils.isLinux();
+PlatformUtils.isAndroid();
+PlatformUtils.isIOS();
+PlatformUtils.isAarch64();
+```
+
+### UserPlatform
+
+The end-user's OS, which might differ from the OS of the JPro server. A common use case is to detect
+the correct modifier key (Cmd on macOS, Ctrl elsewhere):
+
+```java
+UserPlatform.isWindows(webAPI);
+UserPlatform.isMac(webAPI);
+UserPlatform.isMobile(webAPI);
+KeyCode modifier = UserPlatform.getModifierKey(webAPI);
+
+// Testing helpers:
+UserPlatform.simulateNative();
+UserPlatform.simulateWeb(platform, platformOld);
+```
+
+### OpenLink
+
+Opens a URL in the user's default browser (desktop only; throws on unsupported platforms). In the
+browser, use the routing/link APIs instead.
+
+```java
+OpenLink.openURL("https://www.jpro.one");
+OpenLink.openURL(new URL("https://www.jpro.one"));
+```
+
+### CopyUtil
+
+Makes a node copy text to the clipboard when clicked; works on desktop and in JPro.
+
+```java
+CopyUtil.setCopyOnClick(myLabel, "text to copy");
+```
+
+### TreeShowing
+
+A `BooleanProperty` that reflects whether a node is currently attached to a showing scene/window —
+handy for starting/stopping work tied to visibility and for avoiding leaks.
+
+```java
+BooleanProperty showing = TreeShowing.treeShowing(node);
+boolean isShowing = TreeShowing.isTreeShowing(node);
+```
+
+### FreezeDetector
+
+Detects when the JavaFX Application Thread is blocked for longer than a threshold — useful for
+spotting deadlocks and long-running work on the FX thread. Must be constructed on the FX thread.
+
+```java
+new FreezeDetector(Duration.ofSeconds(1), (thread, frozenFor) ->
+        System.out.println("FX thread frozen for " + frozenFor));
+```
+
+### CommandRunner
+
+A thin wrapper around `ProcessBuilder` for running external processes and collecting their output,
+with optional interactive mode, console echo, and masked secret arguments.
+
+```java
+CommandRunner runner = new CommandRunner("git", "status");
+int exitCode = runner.run("git-status");   // see Javadoc for run/runAsync variants
+String output = runner.getResponse();
+```

--- a/jpro-utils/build.gradle
+++ b/jpro-utils/build.gradle
@@ -22,6 +22,12 @@ test {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            // Add README.md as an artifact named DOCUMENTATION.md
+            artifact(source: file('build/docs/DOCUMENTATION.md')) {
+                classifier 'DOCUMENTATION'
+                extension 'md'
+            }
+
             pom {
                 name = 'JPro Utils'
                 description = 'A utility module offering essential tools for various functionalities to enhance the ' +
@@ -30,3 +36,11 @@ publishing {
         }
     }
 }
+
+tasks.register('renameReadme', Copy) {
+    from 'README.md'
+    into layout.buildDirectory.dir('docs')
+    rename 'README.md', 'DOCUMENTATION.md'
+}
+
+javadocJar.dependsOn renameReadme

--- a/jpro-youtube/README.md
+++ b/jpro-youtube/README.md
@@ -1,0 +1,26 @@
+# JPro YouTube
+
+`jpro-youtube` provides a `YoutubeNode` that embeds a YouTube video in a JPro/JavaFX application. In
+the browser it uses a native YouTube `<iframe>`; on the desktop it falls back to a `WebView`.
+
+## Dependency
+
+```groovy
+dependencies {
+    implementation("one.jpro.platform:jpro-youtube:0.7.1")
+}
+```
+
+## Usage
+
+Construct the node with a YouTube video id (the part after `v=` in a watch URL):
+
+```java
+import one.jpro.platform.youtube.YoutubeNode;
+
+// https://www.youtube.com/watch?v=dQw4w9WgXcQ  ->  videoId = "dQw4w9WgXcQ"
+YoutubeNode video = new YoutubeNode("dQw4w9WgXcQ");
+```
+
+`YoutubeNode` is a `StackPane`. It keeps a 16:9 aspect ratio and resizes the embedded player with
+the node, so add it to any layout and size it as usual.

--- a/jpro-youtube/build.gradle
+++ b/jpro-youtube/build.gradle
@@ -5,6 +5,12 @@ dependencies {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            // Add README.md as an artifact named DOCUMENTATION.md
+            artifact(source: file('build/docs/DOCUMENTATION.md')) {
+                classifier 'DOCUMENTATION'
+                extension 'md'
+            }
+
             pom {
                 name = 'JPro Youtube'
                 description = 'A module that makes easy to display Youtube videos inside your JPro/JavaFX applications.'
@@ -12,3 +18,11 @@ publishing {
         }
     }
 }
+
+tasks.register('renameReadme', Copy) {
+    from 'README.md'
+    into layout.buildDirectory.dir('docs')
+    rename 'README.md', 'DOCUMENTATION.md'
+}
+
+javadocJar.dependsOn renameReadme


### PR DESCRIPTION
Documents seven published modules that previously had no per-module documentation, and publishes each README as the `DOCUMENTATION` classifier so the ai-docs plugin discovers them.

**New module READMEs**
- `jpro-routing-dev` — `DevTransformer`, `StatisticsTransformer`.
- `jpro-routing-popup` — `PopupAPI`, `SimplePopup`, `SimplePopups`.
- `jpro-utils` — `PlatformUtils`, `UserPlatform`, `OpenLink`, `CopyUtil`, `TreeShowing`, `FreezeDetector`, `CommandRunner`.
- `jpro-scenegraph` — `SceneGraphSerializer`.
- `jpro-session` — `SessionManager`, `SessionException`.
- `jpro-youtube` — `YoutubeNode`.
- `jpro-html-scrollpane` — `HTMLScrollPaneSkin` (flagged experimental/prototype).

**Build wiring**
- Each module publishes its README as the `DOCUMENTATION` classifier (artifact + `renameReadme` + `javadocJar.dependsOn`).
- All seven added to `subprojectsWithDocs` for the website single-page doc.

Version pins use `0.7.1`, consistent with `syncReadmeVersions.sh --check`.

Verified: `:…:renameReadme` generates `build/docs/DOCUMENTATION.md` for each module; gradle configures clean; sync check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)