### PR TITLE
Rename jpro-auth-routing Filter classes to Transformer; RoutingAuth.filter() -> install()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 0.7.2 (unreleased)
+
+#### Features
+* `jpro-auth-routing`: Added `RoutingAuth`, a high-level entry point for adding Google / OAuth2 / username-password login to a `RouteApp`. One central, swappable configuration owns the session, builds the login UI, auto-serves the login page, and provides `requireLogin()` (gate a route or sub-route) and `install()` (wire in the login page + callbacks). Includes `dummy(...)` and `defaultUser(...)` for tests, local development and desktop "local user" setups. See the module README.
+
+#### Breaking
+* `jpro-auth-routing`: Renamed the route-transformer classes to match the routing `Transformer` vocabulary (reversing the 0.7.0 decision to keep the `Filter` name): `AuthBasicFilter` → `AuthBasicTransformer`, `AuthBasicOAuth2Filter` → `AuthBasicOAuth2Transformer`, `AuthRestrictionFilter` → `AuthRestrictionTransformer`, and `AuthUIProvider.createFilter()` → `createTransformer()`.
+
 ### 0.7.1 (June 14, 2026)
 
 #### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ### 0.7.2 (unreleased)
 
 #### Features
-* `jpro-auth-routing`: Added `RoutingAuth`, a high-level entry point for adding Google / OAuth2 / username-password login to a `RouteApp`. One central, swappable configuration owns the session, builds the login UI, auto-serves the login page, and provides `requireLogin()` (gate a route or sub-route) and `install()` (wire in the login page + callbacks). Includes `dummy(...)` and `defaultUser(...)` for tests, local development and desktop "local user" setups. See the module README.
+* `jpro-auth-routing`: Added `RoutingAuth`, a high-level entry point for adding Google / OAuth2 / username-password login to a `RouteApp` (plus `dummy`/`defaultUser` logins for tests and desktop). See the module README and the `routing-auth` example.
 
 #### Breaking
-* `jpro-auth-routing`: Renamed the route-transformer classes to match the routing `Transformer` vocabulary (reversing the 0.7.0 decision to keep the `Filter` name): `AuthBasicFilter` → `AuthBasicTransformer`, `AuthBasicOAuth2Filter` → `AuthBasicOAuth2Transformer`, `AuthRestrictionFilter` → `AuthRestrictionTransformer`, and `AuthUIProvider.createFilter()` → `createTransformer()`.
+* `jpro-auth-routing`: Renamed the auth route transformers from `*Filter` to `*Transformer` (`AuthBasicFilter`, `AuthBasicOAuth2Filter`, `AuthRestrictionFilter`) and `AuthUIProvider.createFilter()` to `createTransformer()`.
 
 ### 0.7.1 (June 14, 2026)
 

--- a/jpro-auth/README.md
+++ b/jpro-auth/README.md
@@ -167,17 +167,32 @@ so there is no need to add it explicitly.
     ```
   
 ### Combined with the Routing API
-Adding the `jpro-auth-routing` dependency lets you wire authentication into a `RouteApp` with a
-single route filter. The module provides:
+Adding the `jpro-auth-routing` dependency lets you wire authentication into a `RouteApp`.
+
+The easiest way is **`RoutingAuth`** — a single, central configuration that declares your login
+methods and produces the login UI, the login page and the route transformers:
+
+```java
+RoutingAuth auth = RoutingAuth.config()
+        .google(CLIENT_ID, CLIENT_SECRET)
+        .usernamePassword(userManager)
+        .build(this);
+
+return Route.empty()
+        .and(protectedRoutes.transform(auth.requireLogin()))
+        .transform(auth.install());   // serves /login + handles callbacks
+```
+
+See the [`jpro-auth-routing` README](routing/README.md) for the full guide (it also covers dummy /
+desktop "local user" logins). The lower-level building blocks below are what `RoutingAuth` is built
+on, for when you need finer control:
 
 - `UserSession` — stores the logged-in `User` in the JPro session.
-- `AuthUIProviders` — factories for the login UI (`createGoogle`, `createOAuth2`, `createBasicProvider`, `combine`).
-- `AuthBasicFilter` — route filter for username/password authentication.
-- `AuthBasicOAuth2Filter` — route filter for OAuth2/OpenID authentication.
+- `AuthUIProviders` — factories for the login UI (`createGoogle`, `createOAuth2`, `createBasicProvider`, `dummy`, `combine`).
+- `AuthBasicTransformer` — route transformer for username/password authentication.
+- `AuthBasicOAuth2Transformer` — route transformer for OAuth2/OpenID authentication.
 
-> The full reference for these classes lives in the [`jpro-auth-routing` README](routing/README.md).
-
-**Username/password** with `BasicAuthenticationProvider` and `AuthBasicFilter`:
+**Username/password** with `BasicAuthenticationProvider` and `AuthBasicTransformer`:
 
 ```java
 public class BasicLoginApp extends RouteApp {
@@ -205,7 +220,7 @@ public class BasicLoginApp extends RouteApp {
                         : Response.node(authUIProvider.createAuthenticationNode())))
                 .when(request -> userSession.isLoggedIn(), Route.empty()
                         .and(Route.get("/user/signed-in", request -> Response.node(new SignedInPage(this)))))
-                .transform(AuthBasicFilter.create(basicAuthProvider, credentials,
+                .transform(AuthBasicTransformer.create(basicAuthProvider, credentials,
                         user -> {
                             userSession.setUser(user);
                             return Response.redirect("/user/signed-in");
@@ -215,7 +230,7 @@ public class BasicLoginApp extends RouteApp {
 }
 ```
 
-**OAuth2 (Google)** with `AuthUIProviders.createGoogle` and `AuthBasicOAuth2Filter`:
+**OAuth2 (Google)** with `AuthUIProviders.createGoogle` and `AuthBasicOAuth2Transformer`:
 
 ```java
 public class GoogleLoginApp extends RouteApp {
@@ -242,7 +257,7 @@ public class GoogleLoginApp extends RouteApp {
                 .and(Route.get("/", request -> Response.node(uiProvider.createAuthenticationNode())))
                 .when(request -> userSession.isLoggedIn(), Route.empty()
                         .and(Route.get("/user/signed-in", request -> Response.node(new SignedInPage(this)))))
-                .transform(AuthBasicOAuth2Filter.create(googleAuthProvider, userSession,
+                .transform(AuthBasicOAuth2Transformer.create(googleAuthProvider, userSession,
                         user -> Response.redirect("/user/signed-in"),
                         error -> Response.node(new ErrorPage(error))));
     }

--- a/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/basic/BasicLoginApp.java
+++ b/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/basic/BasicLoginApp.java
@@ -12,7 +12,7 @@ import one.jpro.platform.auth.example.basic.page.ErrorPage;
 import one.jpro.platform.auth.example.basic.page.LoginPage;
 import one.jpro.platform.auth.example.basic.page.SignedInPage;
 import one.jpro.platform.auth.example.oauth.OAuthApp;
-import one.jpro.platform.auth.routing.AuthBasicFilter;
+import one.jpro.platform.auth.routing.AuthBasicTransformer;
 import one.jpro.platform.auth.routing.AuthUIProvider;
 import one.jpro.platform.auth.routing.AuthUIProviders;
 import one.jpro.platform.auth.routing.UserSession;
@@ -95,7 +95,7 @@ public class BasicLoginApp extends RouteApp {
                 }))
                 .when(request -> isUserAuthenticated(), Route.empty()
                         .and(Route.get("/user/signed-in", request -> Response.node(new SignedInPage(this)))))
-                .transform(AuthBasicFilter.create(basicAuthProvider, credentials, user -> {
+                .transform(AuthBasicTransformer.create(basicAuthProvider, credentials, user -> {
                     userSession.setUser(user);
                     return Response.redirect("/user/signed-in");
                 }, error -> Response.node(new ErrorPage(error))))

--- a/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/basic/page/LoginPage.java
+++ b/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/basic/page/LoginPage.java
@@ -3,7 +3,7 @@ package one.jpro.platform.auth.example.basic.page;
 import one.jpro.platform.auth.core.basic.LoginPane;
 import one.jpro.platform.auth.core.basic.UsernamePasswordCredentials;
 import one.jpro.platform.auth.core.basic.provider.BasicAuthenticationProvider;
-import one.jpro.platform.auth.routing.AuthBasicFilter;
+import one.jpro.platform.auth.routing.AuthBasicTransformer;
 import one.jpro.platform.auth.routing.AuthUIProvider;
 
 /**

--- a/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/login/GoogleLoginApp.java
+++ b/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/login/GoogleLoginApp.java
@@ -8,7 +8,7 @@ import one.jpro.platform.auth.example.login.page.ErrorPage;
 import one.jpro.platform.auth.example.login.page.LoginPage;
 import one.jpro.platform.auth.example.login.page.SignedInPage;
 import one.jpro.platform.auth.example.oauth.OAuthApp;
-import one.jpro.platform.auth.routing.AuthBasicOAuth2Filter;
+import one.jpro.platform.auth.routing.AuthBasicOAuth2Transformer;
 import one.jpro.platform.auth.routing.AuthUIProviders;
 import one.jpro.platform.auth.routing.UserSession;
 import one.jpro.platform.routing.Response;
@@ -75,7 +75,7 @@ public class GoogleLoginApp extends RouteApp {
                 .and(Route.get("/", request -> Response.node(new LoginPage(googleAuthProvider, uiProvider))))
                 .when(request -> isUserAuthenticated(), Route.empty()
                         .and(Route.get("/user/signed-in", request -> Response.node(new SignedInPage(this, googleAuthProvider)))))
-                .transform(AuthBasicOAuth2Filter.create(googleAuthProvider, userSession,
+                .transform(AuthBasicOAuth2Transformer.create(googleAuthProvider, userSession,
                         user -> Response.redirect("/user/signed-in"),
                         error -> Response.node(new ErrorPage(error))))
                 .transform(DevTransformer.create());

--- a/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/login/page/LoginPage.java
+++ b/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/login/page/LoginPage.java
@@ -4,7 +4,7 @@ import javafx.scene.control.Button;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import one.jpro.platform.auth.core.oauth2.provider.GoogleAuthenticationProvider;
-import one.jpro.platform.auth.routing.AuthBasicOAuth2Filter;
+import one.jpro.platform.auth.routing.AuthBasicOAuth2Transformer;
 import one.jpro.platform.auth.routing.AuthUIProvider;
 
 import java.util.Optional;

--- a/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/oauth/OAuthApp.java
+++ b/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/oauth/OAuthApp.java
@@ -6,7 +6,7 @@ import javafx.collections.ObservableMap;
 import one.jpro.platform.auth.core.AuthAPI;
 import one.jpro.platform.auth.core.oauth2.provider.OpenIDAuthenticationProvider;
 import one.jpro.platform.auth.example.oauth.page.*;
-import one.jpro.platform.auth.routing.AuthBasicOAuth2Filter;
+import one.jpro.platform.auth.routing.AuthBasicOAuth2Transformer;
 import one.jpro.platform.auth.routing.UserSession;
 import one.jpro.platform.routing.Transformer;
 import one.jpro.platform.routing.Response;
@@ -105,7 +105,7 @@ public class OAuthApp extends BaseOAuthApp {
      * @return A {@link Transformer} object configured for OAuth2 authentication flow.
      */
     private Transformer oauth2Filter(OpenIDAuthenticationProvider openIDAuthProvider) {
-        return AuthBasicOAuth2Filter.create(openIDAuthProvider, userSession, user -> {
+        return AuthBasicOAuth2Transformer.create(openIDAuthProvider, userSession, user -> {
             setAuthProvider(openIDAuthProvider);
             return Response.redirect(USER_CONSOLE_PATH);
         }, error -> {

--- a/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/oauth/page/AuthProviderPage.java
+++ b/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/oauth/page/AuthProviderPage.java
@@ -5,7 +5,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.VBox;
 import one.jpro.platform.auth.core.oauth2.provider.OpenIDAuthenticationProvider;
 import one.jpro.platform.auth.example.oauth.OAuthApp;
-import one.jpro.platform.auth.routing.AuthBasicOAuth2Filter;
+import one.jpro.platform.auth.routing.AuthBasicOAuth2Transformer;
 import simplefx.experimental.parts.FXFuture;
 
 import java.util.Optional;
@@ -74,7 +74,7 @@ public class AuthProviderPage extends Page {
 
         final var signInBox = loginApp.createButtonWithDescription(
                 "Sign in with the selected authentication provider.", "Sign In",
-                event -> AuthBasicOAuth2Filter.authorize(this, authProvider, authCredentials));
+                event -> AuthBasicOAuth2Transformer.authorize(this, authProvider, authCredentials));
 
         final var discoveryBox = loginApp.createButtonWithDescription(
                 "The OpenID Connect Discovery provides a client with configuration details.",

--- a/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/proto/RoutingAuthExample.java
+++ b/jpro-auth/example/src/main/java/one/jpro/platform/auth/example/proto/RoutingAuthExample.java
@@ -54,7 +54,7 @@ public class RoutingAuthExample extends RouteApp {
         return Route.empty()
                 .and(Route.get("/", request -> Response.node(publicHome())))
                 .and(protectedRoutes)
-                .transform(auth.filter());  // serves /login + handles callbacks (no /login route needed)
+                .transform(auth.install());  // serves /login + handles callbacks (no /login route needed)
     }
 
     private Node publicHome() {

--- a/jpro-auth/routing/README.md
+++ b/jpro-auth/routing/README.md
@@ -25,12 +25,12 @@ public class MyApp extends RouteApp {
                 .and(Route.get("/", r -> Response.node(new PublicHome())))        // public
                 .and(Route.get("/home", r -> Response.node(new Home(auth.getUser())))
                         .transform(auth.requireLogin()))                          // protected
-                .transform(auth.filter());   // serves /login + handles login callbacks
+                .transform(auth.install());   // serves /login + handles login callbacks
     }
 }
 ```
 
-One method per login option, `requireLogin()` on what to protect, `filter()` on the whole route —
+One method per login option, `requireLogin()` on what to protect, `install()` on the whole route —
 and `/login` is served for you. That's the whole integration; everything below is just variations.
 
 > Build inside `createRoute()` (OAuth2 needs the started `Stage`), and keep `auth` in a field so
@@ -40,7 +40,7 @@ and `/login` is served for you. That's the whole integration; everything below i
 
 **Mix public and protected** — place guarded routes *after* public ones (`and` tries earlier routes first):
 ```java
-Route.empty().and(publicRoutes).and(secret.transform(auth.requireLogin())).transform(auth.filter());
+Route.empty().and(publicRoutes).and(secret.transform(auth.requireLogin())).transform(auth.install());
 ```
 
 **Customize the login page** — `loginResponse` decides what `/login` shows; reuse the built-in buttons via `auth.loginScreen()`:
@@ -79,7 +79,7 @@ The resulting `RoutingAuth`:
 
 | | |
 |---|---|
-| `filter()` | transform for the **whole** route — serves `/login` and handles login callbacks |
+| `install()` | transform for the **whole** route — serves `/login` and handles login callbacks |
 | `requireLogin()` | transform for a route/sub-route — protects it (redirects to the login page) |
 | `loginScreen()` | the combined login UI node, for embedding in a custom login page |
 | `getUser()` · `isLoggedIn()` · `logout()` | current user state |
@@ -89,7 +89,7 @@ The resulting `RoutingAuth`:
 
 `RoutingAuth` is a thin facade over `UserSession`, `AuthUIProviders`
 (`createGoogle` / `createOAuth2` / `createBasicProvider` / `dummy` / `combine`) and the filters
-`AuthBasicFilter`, `AuthBasicOAuth2Filter`, `AuthRestrictionFilter`. Use those directly for finer
+`AuthBasicTransformer`, `AuthBasicOAuth2Transformer`, `AuthRestrictionTransformer`. Use those directly for finer
 control — see the Javadoc and the [`jpro-auth-core` README](../README.md).
 
 ## Try it

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthBasicOAuth2Transformer.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthBasicOAuth2Transformer.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
  *
  * @author Besmir Beqiri
  */
-public interface AuthBasicOAuth2Filter {
+public interface AuthBasicOAuth2Transformer {
 
     /**
      * Creates {@link Route} filter from a given {@link OAuth2AuthenticationProvider},

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthBasicTransformer.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthBasicTransformer.java
@@ -19,7 +19,7 @@ import java.util.function.Function;
  *
  * @author Besmir Beqiri
  */
-public interface AuthBasicFilter {
+public interface AuthBasicTransformer {
 
     /**
      * Creates {@link Route} filter from a given {@link BasicAuthenticationProvider},

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthRestrictionTransformer.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthRestrictionTransformer.java
@@ -4,13 +4,13 @@ import one.jpro.platform.routing.Transformer;
 import one.jpro.platform.routing.Response;
 import org.jetbrains.annotations.NotNull;
 
-public class AuthRestrictionFilter {
+public class AuthRestrictionTransformer {
     /**
      * This makes the whole UI only accessible to authenticated users.
      */
     public static Transformer create(AuthUIProvider routingAuthenticationProvider,
                                                  @NotNull UserSession userSession) {
-        var filter = routingAuthenticationProvider.createFilter();
+        var filter = routingAuthenticationProvider.createTransformer();
         Transformer result1 = (route) -> (request) -> {
             if (userSession.getUser() != null) {
                 return route.apply(request);

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProvider.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProvider.java
@@ -24,5 +24,5 @@ public interface AuthUIProvider {
      *
      * @return a {@link Transformer} to apply to the application route
      */
-    Transformer createFilter();
+    Transformer createTransformer();
 }

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProviders.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProviders.java
@@ -50,13 +50,13 @@ public class AuthUIProviders {
             @Override
             public Node createAuthenticationNode() {
                 var button = createButton.get();
-                button.setOnAction(event -> AuthBasicOAuth2Filter.authorize(button, openidAuthProvider));
+                button.setOnAction(event -> AuthBasicOAuth2Transformer.authorize(button, openidAuthProvider));
                 return button;
             }
 
             @Override
-            public Transformer createFilter() {
-                return AuthBasicOAuth2Filter.create(openidAuthProvider, userSession,
+            public Transformer createTransformer() {
+                return AuthBasicOAuth2Transformer.create(openidAuthProvider, userSession,
                         user -> Response.redirect("/"), // That's ok, let the app handle it.
                         err -> {throw new RuntimeException(err);});
             }
@@ -112,7 +112,7 @@ public class AuthUIProviders {
             }
 
             @Override
-            public Transformer createFilter() {
+            public Transformer createTransformer() {
                 return Transformer.empty();
             }
         };
@@ -153,7 +153,7 @@ public class AuthUIProviders {
             }
 
             @Override
-            public Transformer createFilter() {
+            public Transformer createTransformer() {
                 return Transformer.empty();
             }
         };
@@ -191,9 +191,9 @@ public class AuthUIProviders {
             }
 
             @Override
-            public Transformer createFilter() {
+            public Transformer createTransformer() {
                 return Arrays.stream(providers)
-                        .map(AuthUIProvider::createFilter)
+                        .map(AuthUIProvider::createTransformer)
                         .reduce(Transformer::compose).orElse(Transformer.empty());
             }
         };

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/RoutingAuth.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/RoutingAuth.java
@@ -47,9 +47,9 @@ import java.util.function.Function;
  *         .build(this);
  *
  * return Route.empty()
- *         .and(Route.get("/login", r -> Response.node(auth.loginScreen())))
- *         .and(Route.get("/home",  r -> Response.node(new HomePage())))
- *         .transform(auth.requireLogin());
+ *         .and(Route.get("/home", r -> Response.node(new HomePage())))
+ *         .transform(auth.requireLogin())   // gate the route(s)
+ *         .transform(auth.install());       // serve /login + handle callbacks
  * }</pre>
  *
  * For a desktop local user, automated tests, or local development, swap the configuration:
@@ -90,13 +90,13 @@ public final class RoutingAuth {
 
     /**
      * The transform that wires auth into the app: it serves the login page at the configured
-     * {@code loginPage} path and handles the login callbacks (e.g. OAuth2 redirects). Apply it
-     * to the whole route (outermost). With this in place you don't need to declare a
-     * {@code /login} route yourself — adding auth to an existing app is just this transform
-     * plus {@link #requireLogin()} on the parts you want protected.
+     * {@code loginUrl} and handles the login callbacks (e.g. OAuth2 redirects). Apply it to the
+     * whole route (outermost). With this in place you don't need to declare a {@code /login}
+     * route yourself — adding auth to an existing app is just this transform plus
+     * {@link #requireLogin()} on the parts you want protected.
      */
-    public Transformer filter() {
-        Transformer callbacks = combined.createFilter();
+    public Transformer install() {
+        Transformer callbacks = combined.createTransformer();
         return route -> {
             Route inner = callbacks.apply(route);
             return request -> request.getPath().equals(loginUrl)
@@ -112,7 +112,7 @@ public final class RoutingAuth {
      *
      * <p>Apply it to the whole route to gate the entire app, or place a guarded sub-route
      * <em>after</em> your public routes (so they match first) to mix public and protected pages.
-     * Apply {@link #filter()} to the whole route as well, so login callbacks are always handled.</p>
+     * Apply {@link #install()} to the whole route as well, so login callbacks are always handled.</p>
      */
     public Transformer requireLogin() {
         return route -> request -> userSession.isLoggedIn()
@@ -166,7 +166,7 @@ public final class RoutingAuth {
         }
 
         /** The URL of the login page (default {@code "/login"}); {@link RoutingAuth#requireLogin()}
-         * redirects there and {@link RoutingAuth#filter()} serves it. */
+         * redirects there and {@link RoutingAuth#install()} serves it. */
         public Builder loginUrl(String path) {
             this.loginUrl = path;
             return this;
@@ -277,13 +277,13 @@ public final class RoutingAuth {
                 @Override
                 public Node createAuthenticationNode() {
                     Button b = button.get();
-                    b.setOnAction(e -> AuthBasicOAuth2Filter.authorize(b, provider));
+                    b.setOnAction(e -> AuthBasicOAuth2Transformer.authorize(b, provider));
                     return b;
                 }
 
                 @Override
-                public Transformer createFilter() {
-                    return AuthBasicOAuth2Filter.create(provider, session, user -> {
+                public Transformer createTransformer() {
+                    return AuthBasicOAuth2Transformer.create(provider, session, user -> {
                         onLogin.accept(user);
                         return Response.redirect(loginRedirect);
                     }, onError);
@@ -320,7 +320,7 @@ public final class RoutingAuth {
                 }
 
                 @Override
-                public Transformer createFilter() {
+                public Transformer createTransformer() {
                     return Transformer.empty();
                 }
             };


### PR DESCRIPTION
Aligns `jpro-auth-routing` with the routing `Transformer` vocabulary. In 0.7.0 routing renamed its `Filter` type to `Transformer` but the auth classes deliberately kept `Filter`; with only three of them — and no `*Filter` convention anywhere else in routing — that lone exception caused more confusion than it was worth (a `Filter` and a `Transformer` are the same type here). This reverses that decision.

**Naming only — no behavior change.**

### Renames
- `AuthBasicFilter` → `AuthBasicTransformer`
- `AuthBasicOAuth2Filter` → `AuthBasicOAuth2Transformer`
- `AuthRestrictionFilter` → `AuthRestrictionTransformer`
- `AuthUIProvider.createFilter()` → `createTransformer()`
- `RoutingAuth.filter()` → `install()` — an intent name, since both it and `requireLogin()` return a `Transformer` (a method called `transformer()` would be ambiguous). `install()` reads as "wire the login page + callbacks into the app."

### Also
- Examples and both auth READMEs updated; the parent `jpro-auth/README.md` now points at `RoutingAuth` as the recommended entry point.
- CHANGELOG: `0.7.2 (unreleased)` section documenting the `RoutingAuth` feature (merged in #116, previously unlisted) and this breaking rename.

Hard rename (no deprecated aliases) — pre-1.0.

Verified: `:jpro-auth:routing` and `:jpro-auth:example` compile; demo runs (`-Psample=routing-auth`); no leftover `*Filter`/`createFilter`/`filter()` references; README versions in sync.

Follow-up (separate PR): unify the `onLogin`/`onError` callbacks across all login methods and de-duplicate `RoutingAuth`'s inline OAuth/basic providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)