### PR TITLE
Unify RoutingAuth login callbacks; reuse AuthUIProviders factories

### DIFF
--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProviders.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/AuthUIProviders.java
@@ -19,6 +19,8 @@ import org.jetbrains.annotations.NotNull;
 import javafx.scene.layout.Pane;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class AuthUIProviders {
@@ -46,6 +48,27 @@ public class AuthUIProviders {
     public static AuthUIProvider createOAuth2(@NotNull OpenIDAuthenticationProvider openidAuthProvider,
                                                       @NotNull UserSession userSession,
                                                       @NotNull Supplier<Button> createButton) {
+        return createOAuth2(openidAuthProvider, userSession, createButton,
+                user -> Response.redirect("/"), // That's ok, let the app handle it.
+                err -> {throw new RuntimeException(err);});
+    }
+
+    /**
+     * Creates an AuthUIProvider for OAuth2/OpenID authentication with a custom button and
+     * explicit success/error handling.
+     *
+     * @param openidAuthProvider the OpenID authentication provider
+     * @param userSession        the user session to be used
+     * @param createButton       a supplier that provides the button to be used for authentication
+     * @param onSuccess          turns the authenticated user into the response (e.g. a redirect)
+     * @param onError            turns a failed authentication into the response
+     * @return an AuthUIProvider that provides a button for OAuth2 authentication
+     */
+    public static AuthUIProvider createOAuth2(@NotNull OpenIDAuthenticationProvider openidAuthProvider,
+                                                      @NotNull UserSession userSession,
+                                                      @NotNull Supplier<Button> createButton,
+                                                      @NotNull Function<User, Response> onSuccess,
+                                                      @NotNull Function<Throwable, Response> onError) {
         return new AuthUIProvider() {
             @Override
             public Node createAuthenticationNode() {
@@ -56,9 +79,7 @@ public class AuthUIProviders {
 
             @Override
             public Transformer createTransformer() {
-                return AuthBasicOAuth2Transformer.create(openidAuthProvider, userSession,
-                        user -> Response.redirect("/"), // That's ok, let the app handle it.
-                        err -> {throw new RuntimeException(err);});
+                return AuthBasicOAuth2Transformer.create(openidAuthProvider, userSession, onSuccess, onError);
             }
         };
     }
@@ -74,14 +95,32 @@ public class AuthUIProviders {
 
     /**
      * Creates an AuthUIProvider for basic authentication using a username and password.
+     * After a successful login it navigates to {@code "/"}.
      */
     public static AuthUIProvider createBasicProvider(@NotNull BasicAuthenticationProvider authProvider,
                                                                     @NotNull UserSession userSession) {
+        return createBasicProvider(authProvider, userSession, user -> {}, "/");
+    }
+
+    /**
+     * Creates an AuthUIProvider for basic (username/password) authentication. On success the user
+     * is stored in the session, {@code onSuccess} is invoked, and the app navigates to
+     * {@code redirectUrl}; a failed login is shown inline in the form.
+     *
+     * @param authProvider the basic authentication provider
+     * @param userSession  the user session to store the user in
+     * @param onSuccess    invoked with the user after a successful login
+     * @param redirectUrl  where to navigate after a successful login
+     * @return an AuthUIProvider rendering a username/password form
+     */
+    public static AuthUIProvider createBasicProvider(@NotNull BasicAuthenticationProvider authProvider,
+                                                      @NotNull UserSession userSession,
+                                                      @NotNull Consumer<User> onSuccess,
+                                                      @NotNull String redirectUrl) {
         return new AuthUIProvider() {
             @Override
             public Node createAuthenticationNode() {
                 return new VBox() {{
-                    // Use LoginPane?
                     getChildren().add(new Label("Username:"));
                     var username = new TextField();
                     getChildren().add(username);
@@ -95,19 +134,16 @@ public class AuthUIProviders {
                     Runnable loginAction = () -> {
                         authProvider.authenticate(new UsernamePasswordCredentials(username.getText(), password.getText())).thenAccept(user -> {
                             userSession.setUser(user);
-                            LinkUtil.getSessionManager(button).gotoURL("/");
+                            onSuccess.accept(user);
+                            LinkUtil.getSessionManager(button).gotoURL(redirectUrl);
                         }).exceptionally(error -> {
-                            error.printStackTrace();
-                            infoLabel.setText(error.getCause().getMessage());
+                            infoLabel.setText(error.getCause() != null ? error.getCause().getMessage()
+                                    : error.getMessage());
                             return null;
                         });
                     };
-                    password.setOnAction(event -> {
-                        loginAction.run();
-                    });
-                    button.setOnAction(event -> {
-                        loginAction.run();
-                    });
+                    password.setOnAction(event -> loginAction.run());
+                    button.setOnAction(event -> loginAction.run());
                 }};
             }
 
@@ -141,12 +177,28 @@ public class AuthUIProviders {
      */
     public static AuthUIProvider dummy(@NotNull User user, @NotNull UserSession userSession,
                                        @NotNull String redirectUrl) {
+        return dummy(user, userSession, redirectUrl, u -> {});
+    }
+
+    /**
+     * Creates a fake one-click login as the given user, invoking {@code onSuccess} and navigating
+     * to {@code redirectUrl} after login — for local testing or automated tests.
+     *
+     * @param user        the user to log in as
+     * @param userSession the user session to store the user in
+     * @param redirectUrl where to navigate after the fake login
+     * @param onSuccess   invoked with the user after the fake login
+     * @return an AuthUIProvider that logs in the given user when its button is clicked
+     */
+    public static AuthUIProvider dummy(@NotNull User user, @NotNull UserSession userSession,
+                                       @NotNull String redirectUrl, @NotNull Consumer<User> onSuccess) {
         return new AuthUIProvider() {
             @Override
             public Node createAuthenticationNode() {
                 var button = new Button("Login as " + user.getName());
                 button.setOnAction(event -> {
                     userSession.setUser(user);
+                    onSuccess.accept(user);
                     LinkUtil.getSessionManager(button).gotoURL(redirectUrl);
                 });
                 return button;

--- a/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/RoutingAuth.java
+++ b/jpro-auth/routing/src/main/java/one/jpro/platform/auth/routing/RoutingAuth.java
@@ -5,17 +5,11 @@ import javafx.collections.ObservableMap;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.control.PasswordField;
-import javafx.scene.control.TextField;
-import javafx.scene.layout.VBox;
 import one.jpro.platform.auth.core.AuthAPI;
 import one.jpro.platform.auth.core.authentication.User;
 import one.jpro.platform.auth.core.basic.UserManager;
-import one.jpro.platform.auth.core.basic.UsernamePasswordCredentials;
-import one.jpro.platform.auth.core.basic.provider.BasicAuthenticationProvider;
 import one.jpro.platform.auth.core.oauth2.provider.OpenIDAuthenticationProvider;
 import one.jpro.platform.auth.routing.buttons.GoogleLoginButton;
-import one.jpro.platform.routing.LinkUtil;
 import one.jpro.platform.routing.Request;
 import one.jpro.platform.routing.Response;
 import one.jpro.platform.routing.Route;
@@ -209,14 +203,15 @@ public final class RoutingAuth {
                         .clientSecret(clientSecret)
                         .redirectUri(redirectUri)
                         .create(app.getStage());
-                return oauthUI(provider, session, GoogleLoginButton::new);
+                return AuthUIProviders.createOAuth2(provider, session, GoogleLoginButton::new, onLoginRedirect(), onError);
             });
             return this;
         }
 
         /** Adds a generic OAuth2/OpenID login for an already-configured provider. */
         public Builder oauth2(OpenIDAuthenticationProvider provider) {
-            methods.add((app, session) -> oauthUI(provider, session, () -> new Button("Login")));
+            methods.add((app, session) -> AuthUIProviders.createOAuth2(provider, session,
+                    () -> new Button("Login"), onLoginRedirect(), onError));
             return this;
         }
 
@@ -224,14 +219,14 @@ public final class RoutingAuth {
         public Builder usernamePassword(UserManager userManager, String... roles) {
             methods.add((app, session) -> {
                 var provider = AuthAPI.basicAuth().userManager(userManager).roles(roles).create();
-                return basicUI(provider, session);
+                return AuthUIProviders.createBasicProvider(provider, session, onLogin, loginRedirect);
             });
             return this;
         }
 
         /** Adds a one-click fake login as the given user — for local testing. */
         public Builder dummy(String name, Set<String> roles) {
-            methods.add((app, session) -> AuthUIProviders.dummy(new User(name, roles), session, loginRedirect));
+            methods.add((app, session) -> AuthUIProviders.dummy(new User(name, roles), session, loginRedirect, onLogin));
             return this;
         }
 
@@ -259,6 +254,7 @@ public final class RoutingAuth {
 
             if (autoLoginUser != null && !userSession.isLoggedIn()) {
                 userSession.setUser(autoLoginUser);
+                onLogin.accept(autoLoginUser);
             }
 
             List<AuthUIProvider> providers = new ArrayList<>();
@@ -271,60 +267,12 @@ public final class RoutingAuth {
             return new RoutingAuth(userSession, combined, loginUrl, loginResp);
         }
 
-        private AuthUIProvider oauthUI(OpenIDAuthenticationProvider provider, UserSession session,
-                                       java.util.function.Supplier<Button> button) {
-            return new AuthUIProvider() {
-                @Override
-                public Node createAuthenticationNode() {
-                    Button b = button.get();
-                    b.setOnAction(e -> AuthBasicOAuth2Transformer.authorize(b, provider));
-                    return b;
-                }
-
-                @Override
-                public Transformer createTransformer() {
-                    return AuthBasicOAuth2Transformer.create(provider, session, user -> {
-                        onLogin.accept(user);
-                        return Response.redirect(loginRedirect);
-                    }, onError);
-                }
+        // OAuth2 success: run the onLogin hook, then redirect to loginRedirect.
+        private Function<User, Response> onLoginRedirect() {
+            return user -> {
+                onLogin.accept(user);
+                return Response.redirect(loginRedirect);
             };
         }
-
-        private AuthUIProvider basicUI(BasicAuthenticationProvider provider, UserSession session) {
-            return new AuthUIProvider() {
-                @Override
-                public Node createAuthenticationNode() {
-                    var box = new VBox();
-                    var username = new TextField();
-                    var password = new PasswordField();
-                    var button = new Button("Login");
-                    var info = new Label();
-                    box.getChildren().addAll(new Label("Username:"), username,
-                            new Label("Password:"), password, button, info);
-                    Runnable login = () -> provider.authenticate(
-                                    new UsernamePasswordCredentials(username.getText(), password.getText()))
-                            .thenAccept(user -> {
-                                session.setUser(user);
-                                onLogin.accept(user);
-                                LinkUtil.getSessionManager(button).gotoURL(loginRedirect);
-                            })
-                            .exceptionally(error -> {
-                                info.setText(error.getCause() != null ? error.getCause().getMessage()
-                                        : error.getMessage());
-                                return null;
-                            });
-                    button.setOnAction(e -> login.run());
-                    password.setOnAction(e -> login.run());
-                    return box;
-                }
-
-                @Override
-                public Transformer createTransformer() {
-                    return Transformer.empty();
-                }
-            };
-        }
-
     }
 }


### PR DESCRIPTION
Follow-up to the `RoutingAuth` prototype — the two rough edges flagged in #116: inconsistent callbacks and inline-provider duplication.

### Callbacks
- **`onLogin` now fires for every login method.** It already fired for OAuth2 and username/password; this adds it for `dummy` and `defaultUser`, so the hook is consistent.
- **`onError` stays the OAuth2 error handler.** It returns a `Response` (rendered at the redirect URL), which only fits the redirect-based OAuth2 flow. The username/password form shows failures inline (better UX than navigating away), and `dummy`/`defaultUser` can't fail. Documented as such rather than forced everywhere.

### De-duplication
`RoutingAuth` no longer reimplements the OAuth2/basic providers inline. New additive overloads on `AuthUIProviders` carry the success/error handling, and `RoutingAuth` reuses them:
- `createOAuth2(provider, session, button, onSuccess, onError)`
- `createBasicProvider(provider, session, onSuccess, redirectUrl)`
- `dummy(user, session, redirectUrl, onSuccess)`

Existing factory signatures are unchanged (the new ones are overloads), so nothing downstream breaks. Net result: `RoutingAuth` shrank ~50 lines, and the login behavior lives in one place.

No API churn beyond the additive overloads; `RoutingAuth` is unreleased (from #116), so this needs no separate CHANGELOG entry.

Verified: `:jpro-auth:routing` and `:jpro-auth:example` compile; demo runs (`-Psample=routing-auth`); no inline providers remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)