### PR TITLE
jpro-webrtc: cleanup, encapsulation, and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 #### Features
 * `jpro-auth-routing`: Added `RoutingAuth`, a high-level entry point for adding Google / OAuth2 / username-password login to a `RouteApp` (plus `dummy`/`defaultUser` logins for tests and desktop). See the module README and the `routing-auth` example.
+* `jpro-webrtc`: Added a README and Javadoc, plus an `RTCPeerConnection.addStream(MediaStream)` convenience.
 
 #### Breaking
 * `jpro-auth-routing`: Renamed the auth route transformers from `*Filter` to `*Transformer` (`AuthBasicFilter`, `AuthBasicOAuth2Filter`, `AuthRestrictionFilter`) and `AuthUIProvider.createFilter()` to `createTransformer()`.
+* `jpro-webrtc`: Encapsulated the public API — connection states are read-only properties (`connectionStateProperty()`, …), `getTracks()`/`getIceCandidates()` replace the public lists, `setOnNewIceCandidate`/`setOnNegotiationNeeded` replace the public callback fields, and `MediaStream.js` is now `MediaStream.js()`.
 
 ### 0.7.1 (June 14, 2026)
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ def subprojectsWithDocs = [
         "jpro-session",
         "jpro-html-scrollpane",
         "jpro-youtube",
-        "jpro-utils"
+        "jpro-utils",
+        "jpro-webrtc"
 ]
 
 tasks.register('combineDocumentationFull') {

--- a/jpro-sipjs/example/src/main/java/one/jpro/platform/sipjs/example/component/User.java
+++ b/jpro-sipjs/example/src/main/java/one/jpro/platform/sipjs/example/component/User.java
@@ -149,7 +149,7 @@ public class User extends VBox {
             isScreenSharing = !isScreenSharing;
             var stream = isScreenSharing ? MediaStream.getScreenStream(webapi)
                     : MediaStream.getCameraStream(webapi);
-            stream.js.exceptionally(e -> {
+            stream.js().exceptionally(e -> {
                 System.out.println("Error getting video stream");
                 e.printStackTrace();
                 return null;

--- a/jpro-sipjs/src/main/java/one/jpro/platform/sipjs/api/session/Session.java
+++ b/jpro-sipjs/src/main/java/one/jpro/platform/sipjs/api/session/Session.java
@@ -70,7 +70,7 @@ public class Session {
      * @param stream
      */
     public void switchToStream(MediaStream stream) {
-        stream.js.thenAccept(js -> {
+        stream.js().thenAccept(js -> {
             webapi.js().eval("var videoTrack = "+js.getName()+".getVideoTracks()[0];\n" +
                     "var sender = "+session.getName()+".sessionDescriptionHandler.peerConnection.getSenders().find(function(s) {\n" +
                     "  return s.track.kind == videoTrack.kind;\n" +

--- a/jpro-webrtc/README.md
+++ b/jpro-webrtc/README.md
@@ -1,0 +1,77 @@
+# JPro WebRTC
+
+`jpro-webrtc` adds real-time audio/video communication to JPro applications by wrapping the
+browser's [WebRTC](https://developer.mozilla.org/docs/Web/API/WebRTC_API) API in JavaFX-friendly
+classes. It runs **in the browser only** (every class needs a JPro `WebAPI`).
+
+## Dependency
+
+```groovy
+dependencies {
+    implementation("one.jpro.platform:jpro-webrtc:0.7.1")
+}
+```
+
+## What's inside
+
+| Class | Purpose |
+|---|---|
+| `RTCPeerConnection` | A peer connection — offer/answer/ICE, observable state, received tracks. |
+| `MediaStream` | The user's camera (`getCameraStream`) or screen (`getScreenStream`). |
+| `VideoFrame` | A JavaFX node that displays a media stream (`setStream(...)`). |
+| `RTCDetails` | A small debug view of a connection's live state. |
+
+## Two peers on one page
+
+The quickest way to see it work — connect two local peer connections directly (no signaling server),
+each showing the other's camera:
+
+```java
+var rtc1 = new RTCPeerConnection(getWebAPI());
+var rtc2 = new RTCPeerConnection(getWebAPI());
+
+var video1 = new VideoFrame(getWebAPI());
+var video2 = new VideoFrame(getWebAPI());
+
+// show each peer's incoming track in the matching video frame
+rtc1.getTracks().addListener((ListChangeListener<JSVariable>) c ->
+        { while (c.next()) c.getAddedSubList().forEach(video1::setStream); });
+rtc2.getTracks().addListener((ListChangeListener<JSVariable>) c ->
+        { while (c.next()) c.getAddedSubList().forEach(video2::setStream); });
+
+// add each camera, then connect the two peers
+var f1 = rtc1.addStream(MediaStream.getCameraStream(getWebAPI()));
+var f2 = rtc2.addStream(MediaStream.getCameraStream(getWebAPI()));
+f1.thenCompose(a -> f2).thenRun(() -> RTCPeerConnection.connectConnections(rtc1, rtc2));
+```
+
+`connectConnections(...)` forwards ICE candidates both ways and renegotiates automatically — it's
+for demos and tests within a single page.
+
+## Real applications: signaling
+
+Connecting two *different* browsers requires a **signaling channel** (a WebSocket, the routing
+session, a backend, …) to exchange the offer/answer SDP and ICE candidates. `jpro-webrtc` gives you
+the pieces; the transport is yours:
+
+```java
+// caller
+String offer = rtc.createOfferAndSetLocal().get();   // send to the other peer via your channel
+rtc.setOnNewIceCandidate(candidate -> /* send candidate over your channel */);
+
+// on the other peer
+rtc.setRemoteDescription(offer);
+String answer = rtc.createAnswerAndSetLocal().get(); // send back
+rtc.addIceCandidate(candidateFromPeer);              // for each received candidate
+```
+
+Observe `connectionStateProperty()`, `iceConnectionStateProperty()`, `iceGatheringStateProperty()`
+and `signalingStateProperty()` to track progress (or drop an `RTCDetails` node into your scene).
+
+## Running the example
+
+```bash
+./gradlew jpro-webrtc:example:jproRun
+```
+
+A multi-user video room (`VideoRoomApp`); `WebRTCSimple` shows the two-peers-on-one-page setup above.

--- a/jpro-webrtc/build.gradle
+++ b/jpro-webrtc/build.gradle
@@ -5,6 +5,12 @@ dependencies {
 publishing {
     publications {
         mavenJava(MavenPublication) {
+            // Add README.md as an artifact named DOCUMENTATION.md
+            artifact(source: file('build/docs/DOCUMENTATION.md')) {
+                classifier 'DOCUMENTATION'
+                extension 'md'
+            }
+
             pom {
                 name = 'JPro WebRTC'
                 description = 'A module that makes easy to add real-time communication capabilities to your web applications running with JPro.'
@@ -12,3 +18,11 @@ publishing {
         }
     }
 }
+
+tasks.register('renameReadme', Copy) {
+    from 'README.md'
+    into layout.buildDirectory.dir('docs')
+    rename 'README.md', 'DOCUMENTATION.md'
+}
+
+javadocJar.dependsOn renameReadme

--- a/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/simple/WebRTCSimple.java
+++ b/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/simple/WebRTCSimple.java
@@ -26,14 +26,14 @@ public class WebRTCSimple extends JProApplication {
         var video1 = new VideoFrame(getWebAPI());
         var video2 = new VideoFrame(getWebAPI());
 
-        rtc1.tracks.addListener((ListChangeListener<? super JSVariable>)  change -> {
+        rtc1.getTracks().addListener((ListChangeListener<? super JSVariable>)  change -> {
             while(change.next()) {
                 if(change.wasAdded()) {
                     video1.setStream(change.getAddedSubList().get(0));
                 }
             }
         });
-        rtc2.tracks.addListener((ListChangeListener<? super JSVariable>)  change -> {
+        rtc2.getTracks().addListener((ListChangeListener<? super JSVariable>)  change -> {
             while(change.next()) {
                 if(change.wasAdded()) {
                     video2.setStream(change.getAddedSubList().get(0));
@@ -41,12 +41,8 @@ public class WebRTCSimple extends JProApplication {
             }
         });
 
-        var f1 = MediaStream.getCameraStream(rtc1.getWebAPI()).js.thenAccept(stream -> {
-            rtc1.addStream(stream);
-        });
-        var f2 = MediaStream.getCameraStream(rtc2.getWebAPI()).js.thenAccept(stream -> {
-            rtc2.addStream(stream);
-        });
+        var f1 = rtc1.addStream(MediaStream.getCameraStream(rtc1.getWebAPI()));
+        var f2 = rtc2.addStream(MediaStream.getCameraStream(rtc2.getWebAPI()));
 
         (f1.thenCompose(a -> f2)).thenAccept( r ->
             RTCPeerConnection.connectConnections(rtc1, rtc2)

--- a/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/videoroom/model/VideoRoom.java
+++ b/jpro-webrtc/example/src/main/java/one/jpro/platform/webrtc/example/videoroom/model/VideoRoom.java
@@ -51,16 +51,16 @@ public class VideoRoom {
         var video1 = new VideoFrame(webAPI1);
         var video2 = new VideoFrame(webAPI2);
 
-        rtc1.tracks.addListener((ListChangeListener<? super JSVariable>) change -> {
-            System.out.println("tracks size for user 1: " + rtc1.tracks.size());
+        rtc1.getTracks().addListener((ListChangeListener<? super JSVariable>) change -> {
+            System.out.println("tracks size for user 1: " + rtc1.getTracks().size());
             while(change.next()) {
                 if(change.wasAdded()) {
                     video1.setStream(change.getAddedSubList().get(0));
                 }
             }
         });
-        rtc2.tracks.addListener((ListChangeListener<? super JSVariable>)  change -> {
-            System.out.println("tracks size for user 2: " + rtc2.tracks.size());
+        rtc2.getTracks().addListener((ListChangeListener<? super JSVariable>)  change -> {
+            System.out.println("tracks size for user 2: " + rtc2.getTracks().size());
             while(change.next()) {
                 if(change.wasAdded()) {
                     video2.setStream(change.getAddedSubList().get(0));
@@ -72,7 +72,7 @@ public class VideoRoom {
             try {
                 //rtc1.removeAllTracks();
                 rtc1.removeStream(oldValue);
-                newValue.js.thenAccept(stream -> {
+                newValue.js().thenAccept(stream -> {
                     rtc1.addStream(stream);
                 });
             } catch (Exception e) {
@@ -83,17 +83,17 @@ public class VideoRoom {
             try {
                 //rtc2.removeAllTracks();
                 rtc2.removeStream(oldValue);
-                newValue.js.thenAccept(stream -> {
+                newValue.js().thenAccept(stream -> {
                     rtc2.addStream(stream);
                 });
             } catch (Exception e) {
                 e.printStackTrace();
             }
         });
-        var f1 = user1.mediaStream.get().js.thenAccept(stream -> {
+        var f1 = user1.mediaStream.get().js().thenAccept(stream -> {
             rtc1.addStream(stream);
         });
-        var f2 = user2.mediaStream.get().js.thenAccept(stream -> {
+        var f2 = user2.mediaStream.get().js().thenAccept(stream -> {
             rtc2.addStream(stream);
         });
 

--- a/jpro-webrtc/src/main/java/one/jpro/platform/webrtc/MediaStream.java
+++ b/jpro-webrtc/src/main/java/one/jpro/platform/webrtc/MediaStream.java
@@ -5,18 +5,30 @@ import com.jpro.webapi.WebAPI;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A browser media stream (camera or screen capture), obtained asynchronously via the JavaScript
+ * {@code navigator.mediaDevices} API. The underlying JS stream is available through {@link #js()}.
+ */
 public class MediaStream {
 
-    public CompletableFuture<JSVariable> js;
+    private final CompletableFuture<JSVariable> js;
+
     MediaStream(WebAPI webAPI, CompletableFuture<JSVariable> js) {
         this.js = js;
     }
 
+    /** The underlying JS {@code MediaStream}, available once the user has granted access. */
+    public CompletableFuture<JSVariable> js() {
+        return js;
+    }
+
+    /** Requests the user's camera (video only). */
     public static MediaStream getCameraStream(WebAPI webAPI) {
         var js = webAPI.executeJSAsync("return await navigator.mediaDevices.getUserMedia({video: true, audio: false});");
         return new MediaStream(webAPI, js);
     }
 
+    /** Requests screen capture (a window, video only). */
     public static MediaStream getScreenStream(WebAPI webAPI) {
         var js = webAPI.executeJSAsync("return await navigator.mediaDevices.getDisplayMedia({video: {\n" +
                 "      displaySurface: \"window\",\n" +

--- a/jpro-webrtc/src/main/java/one/jpro/platform/webrtc/RTCDetails.java
+++ b/jpro-webrtc/src/main/java/one/jpro/platform/webrtc/RTCDetails.java
@@ -1,52 +1,38 @@
 package one.jpro.platform.webrtc;
 
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
 
 /**
- * This class shows various details of an RTCPeerConnection.
+ * A small debug view that shows the live state of an {@link RTCPeerConnection} — its connection,
+ * ICE and signaling states, and the number of ICE candidates and tracks.
  */
 public class RTCDetails extends VBox {
 
-    private RTCPeerConnection rtc;
     public RTCDetails(RTCPeerConnection rtc) {
-        this.rtc = rtc;
+        getChildren().add(createLabel("connectionState", rtc.connectionStateProperty()));
+        getChildren().add(createLabel("iceConnectionState", rtc.iceConnectionStateProperty()));
+        getChildren().add(createLabel("iceGatheringState", rtc.iceGatheringStateProperty()));
+        getChildren().add(createLabel("signalingState", rtc.signalingStateProperty()));
 
-
-        getChildren().add(createLabel("connectionState", rtc.connectionState));
-        getChildren().add(createLabel("iceConnectionState", rtc.iceConnectionState));
-        getChildren().add(createLabel("iceGatheringState", rtc.iceGatheringState));
-        getChildren().add(createLabel("signalingState", rtc.signalingState));
-
-        getChildren().add(createSizeLabel("iceCandidates", rtc.iceCandidates));
-        getChildren().add(createSizeLabel("trackCount", rtc.tracks));
+        getChildren().add(createSizeLabel("iceCandidates", rtc.getIceCandidates()));
+        getChildren().add(createSizeLabel("trackCount", rtc.getTracks()));
     }
 
-    private Label createLabel(String name, StringProperty prop) {
+    private Label createLabel(String name, ReadOnlyStringProperty prop) {
         var label = new Label();
         label.textProperty().bind(Bindings.concat(name, ": ", prop));
         return label;
     }
 
     private <T> Label createSizeLabel(String name, ObservableList<T> list) {
-        var label = new Label();
-        //label.textProperty().bind(Bindings.concat(name, ": ", Bindings.size(list)));
-        // put in the whole list
-        //label.textProperty().bind(Bindings.concat(name, ": ", list));
-        // but add listener for List
-        list.addListener((ListChangeListener<? super T>) change -> {
-            while(change.next()) {
-                if(change.wasAdded()) {
-                    label.setText(name + ": " + list.size());
-                }
-            }
-        });
-        label.wrapTextProperty().setValue(true);
+        var label = new Label(name + ": " + list.size());
+        list.addListener((ListChangeListener<? super T>) change -> label.setText(name + ": " + list.size()));
+        label.setWrapText(true);
         return label;
     }
-
 }

--- a/jpro-webrtc/src/main/java/one/jpro/platform/webrtc/RTCPeerConnection.java
+++ b/jpro-webrtc/src/main/java/one/jpro/platform/webrtc/RTCPeerConnection.java
@@ -2,8 +2,8 @@ package one.jpro.platform.webrtc;
 
 import com.jpro.webapi.JSVariable;
 import com.jpro.webapi.WebAPI;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -13,34 +13,46 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+/**
+ * A JavaFX-friendly wrapper around the browser's
+ * <a href="https://developer.mozilla.org/docs/Web/API/RTCPeerConnection">{@code RTCPeerConnection}</a>.
+ *
+ * <p>It exposes the connection state as observable properties, the received tracks and gathered ICE
+ * candidates as observable lists, and the offer/answer/ICE operations as {@link CompletableFuture}s.
+ * Runs in the browser only (it needs a JPro {@link WebAPI}). For a local two-peer setup, see
+ * {@link #connectConnections(RTCPeerConnection, RTCPeerConnection)}.</p>
+ */
 public class RTCPeerConnection {
 
-    private static String defaultConf = "{ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] }";
+    private static final String defaultConf = "{ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] }";
 
-    public StringProperty connectionState = new SimpleStringProperty("new");
+    private final ReadOnlyStringWrapper connectionState = new ReadOnlyStringWrapper("new");
+    private final ReadOnlyStringWrapper iceConnectionState = new ReadOnlyStringWrapper("new");
+    private final ReadOnlyStringWrapper iceGatheringState = new ReadOnlyStringWrapper("new");
+    private final ReadOnlyStringWrapper signalingState = new ReadOnlyStringWrapper("stable");
 
-    public StringProperty iceConnectionState = new SimpleStringProperty("new");
+    private final ObservableList<JSVariable> tracks = FXCollections.observableArrayList();
+    private final ObservableList<JSVariable> tracksView = FXCollections.unmodifiableObservableList(tracks);
+    private final ObservableList<String> iceCandidates = FXCollections.observableArrayList();
+    private final ObservableList<String> iceCandidatesView = FXCollections.unmodifiableObservableList(iceCandidates);
 
-    public StringProperty iceGatheringState = new SimpleStringProperty("new");
+    private Consumer<String> onNewIceCandidate = str -> {};
+    private Runnable onNegotiationNeeded = () -> {};
 
-    public StringProperty signalingState = new SimpleStringProperty("stable");
+    private final WebAPI webAPI;
+    private final Set<Object> hardReferences = new HashSet<>();
+    private final JSVariable js;
 
-    private WebAPI webAPI;
-    private Set<Object> hardReferences = new HashSet<>();
-
-    public ObservableList<JSVariable> tracks = FXCollections.observableArrayList();
-    public ObservableList<String> iceCandidates = FXCollections.observableArrayList();
-
-    public Consumer<String> onNewIceCandidate = str -> {};
-
-    public Runnable onnegotiationneeded = () -> {};
-
-    JSVariable js;
-
+    /** Creates a peer connection with a default STUN configuration. */
     public RTCPeerConnection(WebAPI webAPI) {
         this(webAPI, defaultConf);
     }
 
+    /**
+     * Creates a peer connection with a custom configuration.
+     *
+     * @param conf the JSON {@code RTCConfiguration} (e.g. {@code "{ iceServers: [...] }"})
+     */
     public RTCPeerConnection(WebAPI webAPI, String conf) {
         this.webAPI = webAPI;
         js = webAPI.executeScriptWithVariable("new RTCPeerConnection(" + conf + ");");
@@ -55,33 +67,85 @@ public class RTCPeerConnection {
             tracks.add(track);
         });
 
-        listenToJS("icecandidate", iceCandidate -> {
-            //System.out.println("TO EXECUTE: " + "" + iceCandidate.getName() + ".candidate");
-            webAPI.executeScriptWithFuture("" + iceCandidate.getName() + ".candidate").thenAccept(str -> {
+        listenToJS("icecandidate", iceCandidate ->
+            webAPI.executeScriptWithFuture(iceCandidate.getName() + ".candidate").thenAccept(str -> {
                 iceCandidates.add(str);
                 onNewIceCandidate.accept(str);
-            });
-        });
+            }));
 
-        listenToJS("negotiationneeded", e -> {
-            System.out.println("negotiationneeded: " + "" + e.getName());
-            onnegotiationneeded.run();
-        });
+        listenToJS("negotiationneeded", e -> onNegotiationNeeded.run());
     }
 
+    /** Returns the {@link WebAPI} this connection runs on. */
     public WebAPI getWebAPI() {
         return webAPI;
     }
 
-    public void listenToJS(String propName, Consumer<JSVariable> setter) {
+    /** The connection state ({@code new}, {@code connecting}, {@code connected}, …). */
+    public ReadOnlyStringProperty connectionStateProperty() {
+        return connectionState.getReadOnlyProperty();
+    }
+
+    public String getConnectionState() {
+        return connectionState.get();
+    }
+
+    /** The ICE connection state. */
+    public ReadOnlyStringProperty iceConnectionStateProperty() {
+        return iceConnectionState.getReadOnlyProperty();
+    }
+
+    public String getIceConnectionState() {
+        return iceConnectionState.get();
+    }
+
+    /** The ICE gathering state. */
+    public ReadOnlyStringProperty iceGatheringStateProperty() {
+        return iceGatheringState.getReadOnlyProperty();
+    }
+
+    public String getIceGatheringState() {
+        return iceGatheringState.get();
+    }
+
+    /** The signaling state. */
+    public ReadOnlyStringProperty signalingStateProperty() {
+        return signalingState.getReadOnlyProperty();
+    }
+
+    public String getSignalingState() {
+        return signalingState.get();
+    }
+
+    /** The remote media tracks received on this connection (read-only, observable). */
+    public ObservableList<JSVariable> getTracks() {
+        return tracksView;
+    }
+
+    /** The local ICE candidates gathered for this connection (read-only, observable). */
+    public ObservableList<String> getIceCandidates() {
+        return iceCandidatesView;
+    }
+
+    /** Sets the callback invoked for each new local ICE candidate (forward it to the remote peer). */
+    public void setOnNewIceCandidate(Consumer<String> onNewIceCandidate) {
+        this.onNewIceCandidate = onNewIceCandidate;
+    }
+
+    /** Sets the callback invoked when (re)negotiation is needed. */
+    public void setOnNegotiationNeeded(Runnable onNegotiationNeeded) {
+        this.onNegotiationNeeded = onNegotiationNeeded;
+    }
+
+    private void listenToJS(String propName, Consumer<JSVariable> setter) {
         var jsFun = webAPI.registerJavaFunctionWithVariable(setter);
-        webAPI.executeScript(js.getName() + ".on" + propName + " = function(str){ console.log('str: ' + str); " + jsFun.getName() + "(str);};");
+        webAPI.executeScript(js.getName() + ".on" + propName + " = function(str){ " + jsFun.getName() + "(str);};");
         hardReferences.add(jsFun);
     }
 
-    public void listenToProperty(String propName, Consumer<String> setter) {
+    private void listenToProperty(String propName, Consumer<String> setter) {
         var jsFun = webAPI.registerJavaFunction(str -> {
-            // remove first and last character
+            // strip the surrounding quotes added by the JS bridge
             str = str.substring(1, str.length() - 1);
             setter.accept(str);
         });
@@ -90,64 +154,67 @@ public class RTCPeerConnection {
         hardReferences.add(jsFun);
     }
 
+    /** Creates an offer and sets it as the local description; resolves with the offer SDP. */
     public CompletableFuture<String> createOfferAndSetLocal() {
         return webAPI.executeJSAsync("const offer = await "+js.getName()+".createOffer();" +
           "await "+js.getName()+".setLocalDescription(offer);" +
-          "return offer;").thenCompose(js -> {
-            return webAPI.executeScriptWithFuture(js.getName());});
+          "return offer;").thenCompose(js -> webAPI.executeScriptWithFuture(js.getName()));
     }
 
+    /** Creates an answer and sets it as the local description; resolves with the answer SDP. */
     public CompletableFuture<String> createAnswerAndSetLocal() {
         return webAPI.executeJSAsync("const answer = await "+js.getName()+".createAnswer();" +
           "await "+js.getName()+".setLocalDescription(answer);" +
-          "return answer;").thenCompose(js -> {
-            return webAPI.executeScriptWithFuture(js.getName());});
+          "return answer;").thenCompose(js -> webAPI.executeScriptWithFuture(js.getName()));
     }
 
+    /** Sets the local session description from the given SDP. */
     public CompletableFuture<JSVariable> setLocalDescription(String sdp) {
         return webAPI.executeJSAsync("return await " + js.getName() + ".setLocalDescription(" + sdp + ");");
     }
 
+    /** Sets the remote session description from the given SDP. */
     public CompletableFuture<JSVariable> setRemoteDescription(String sdp) {
         return webAPI.executeJSAsync("return await " + js.getName() + ".setRemoteDescription(new RTCSessionDescription(" + sdp + "));");
     }
 
+    /** Adds all tracks of the given media stream to this connection. */
+    public CompletableFuture<String> addStream(MediaStream stream) {
+        return stream.js().thenCompose(this::addStream);
+    }
+
+    /** Adds all tracks of the given (already resolved) media stream to this connection. */
     public CompletableFuture<String> addStream(JSVariable stream) {
         return webAPI.executeScriptWithFuture(stream.getName() + ".getTracks().forEach(function(track) {" +
           js.getName() + ".addTrack(track, " + stream.getName() + ");" +
           "}); undefined;");
     }
 
+    /** Stops and removes all senders' tracks for the given stream. */
     public CompletableFuture<JSVariable> removeStream(MediaStream stream) {
-        return stream.js.thenApply(s -> {
-            return webAPI.executeScriptWithVariable(js.getName() + ".getSenders().forEach(sender => {" +
+        return stream.js().thenApply(s ->
+            webAPI.executeScriptWithVariable(js.getName() + ".getSenders().forEach(sender => {" +
               "if (sender.track) {" +
               "sender.track.stop();" +
               "}" +
               js.getName() + ".removeTrack(sender);" +
-              "});");
-        });
+              "});"));
     }
 
-    //public void removeAllTracks() {
-    //    webAPI.executeScript(js.getName() + ".getSenders().forEach(sender => {" +
-    //      "if (sender.track) {" +
-    //      "sender.track.stop();" +
-    //      "}" +
-    //      js.getName() + ".removeTrack(sender);" +
-    //      "});");
-    //}
-
+    /** Adds a single track to this connection. */
     public void addTrack(JSVariable track) {
         webAPI.executeScript(js.getName() + ".addTrack(" + track.getName() + ");");
     }
 
-    public void removeTracks(JSVariable stream) {
-        webAPI.executeScript(js.getName() + ".removeTrack(" + stream.getName() + ");");
+    /** Removes a single track sender from this connection. */
+    public void removeTrack(JSVariable track) {
+        webAPI.executeScript(js.getName() + ".removeTrack(" + track.getName() + ");");
     }
 
     /**
-     * Sets the remote ICE candidates.
+     * Adds a remote ICE candidate received from the other peer.
+     *
+     * @param iceCandidate the candidate JSON; must not be {@code null} or the string {@code "null"}
      */
     public void addIceCandidate(String iceCandidate) {
         if(iceCandidate == null) {
@@ -159,55 +226,39 @@ public class RTCPeerConnection {
         webAPI.executeScript(js.getName() + ".addIceCandidate(new RTCIceCandidate(" + iceCandidate + "));");
     }
 
+    /**
+     * Wires two local peer connections directly together: forwards ICE candidates both ways and
+     * (re)negotiates whenever needed. Useful for demos and tests within a single page.
+     */
     public static void connectConnections(RTCPeerConnection rtc1, RTCPeerConnection rtc2) {
-
-        // Link ice candidates
-        rtc1.iceCandidates.stream().forEach(rtc2::addIceCandidate);
-        rtc2.iceCandidates.stream().forEach(rtc1::addIceCandidate);
-        rtc1.onNewIceCandidate = (rtc2::addIceCandidate);
-        rtc2.onNewIceCandidate = (rtc1::addIceCandidate);
+        // Link ICE candidates both ways
+        rtc1.iceCandidates.forEach(rtc2::addIceCandidate);
+        rtc2.iceCandidates.forEach(rtc1::addIceCandidate);
+        rtc1.onNewIceCandidate = rtc2::addIceCandidate;
+        rtc2.onNewIceCandidate = rtc1::addIceCandidate;
 
         AtomicBoolean isNegotiating = new AtomicBoolean(false);
-
-        //rtc1.onnegotiationneeded = () -> {
-        //    negotiate(rtc1, rtc2);
-        //};
-        //rtc2.onnegotiationneeded = () -> {
-        //    negotiate(rtc2, rtc1);
-        //};
-
-        rtc1.onnegotiationneeded = () -> {
+        rtc1.onNegotiationNeeded = () -> {
             if(!isNegotiating.get()) {
                 isNegotiating.set(true);
-                negotiate(rtc1, rtc2).thenRun(() -> {
-                    isNegotiating.set(false);
-                });
+                negotiate(rtc1, rtc2).thenRun(() -> isNegotiating.set(false));
             }
         };
-        rtc2.onnegotiationneeded = () -> {
+        rtc2.onNegotiationNeeded = () -> {
             if(!isNegotiating.get()) {
                 isNegotiating.set(true);
-                negotiate(rtc2, rtc1).thenRun(() -> {
-                    isNegotiating.set(false);
-                });
+                negotiate(rtc2, rtc1).thenRun(() -> isNegotiating.set(false));
             }
         };
         isNegotiating.set(true);
-        negotiate(rtc1, rtc2).thenRun(() -> {
-            isNegotiating.set(false);
-        });
+        negotiate(rtc1, rtc2).thenRun(() -> isNegotiating.set(false));
     }
 
+    /** Runs one offer/answer negotiation round from {@code rtc1} to {@code rtc2}. */
     public static CompletableFuture<JSVariable> negotiate(RTCPeerConnection rtc1, RTCPeerConnection rtc2) {
-
-        return rtc1.createOfferAndSetLocal().thenCompose(sdp -> {
-            //System.out.println("OFFER: " + sdp);
-            return rtc2.setRemoteDescription(sdp).thenCompose(s -> {
-                return rtc2.createAnswerAndSetLocal().thenCompose(sdp2 -> {
-                    //System.out.println("ANSWER: " + sdp2);
-                    return rtc1.setRemoteDescription(sdp2);
-                });
-            });
-        });
+        return rtc1.createOfferAndSetLocal().thenCompose(sdp ->
+            rtc2.setRemoteDescription(sdp).thenCompose(s ->
+                rtc2.createAnswerAndSetLocal().thenCompose(sdp2 ->
+                    rtc1.setRemoteDescription(sdp2))));
     }
 }

--- a/jpro-webrtc/src/main/java/one/jpro/platform/webrtc/VideoFrame.java
+++ b/jpro-webrtc/src/main/java/one/jpro/platform/webrtc/VideoFrame.java
@@ -4,13 +4,15 @@ import com.jpro.webapi.HTMLView;
 import com.jpro.webapi.JSVariable;
 import com.jpro.webapi.WebAPI;
 
+/**
+ * A JavaFX node that renders a live media stream, backed by an HTML {@code <video>} element.
+ * Set the stream to display with {@link #setStream(MediaStream)}.
+ */
 public class VideoFrame extends HTMLView {
 
-    private WebAPI webAPI;
-    JSVariable elem;
-
-    JSVariable videoElem;
-
+    private final WebAPI webAPI;
+    private final JSVariable elem;
+    private final JSVariable videoElem;
 
     public VideoFrame(WebAPI webAPI) {
         super("<video autoplay playsinline ></video>");
@@ -20,24 +22,24 @@ public class VideoFrame extends HTMLView {
 
         setPrefSize(100,100);
 
-        widthProperty().addListener((observable, oldValue, newValue) -> {
-            webAPI.executeScript(videoElem.getName()+".width = "+newValue.intValue()+";");
-        });
-        heightProperty().addListener((observable, oldValue, newValue) -> {
-            webAPI.executeScript(videoElem.getName()+".height = "+newValue.intValue()+";");
-        });
+        widthProperty().addListener((observable, oldValue, newValue) ->
+            webAPI.executeScript(videoElem.getName()+".width = "+newValue.intValue()+";"));
+        heightProperty().addListener((observable, oldValue, newValue) ->
+            webAPI.executeScript(videoElem.getName()+".height = "+newValue.intValue()+";"));
     }
 
+    /** The underlying HTML {@code <video>} element (low-level). */
     public JSVariable getVideoElem() {
         return videoElem;
     }
 
+    /** Displays the given media stream once it is available. */
     public void setStream(MediaStream stream) {
-        stream.js.thenAccept(s -> {
-            webAPI.executeScript(videoElem.getName()+".srcObject = "+s.getName()+";");
-        });
+        stream.js().thenAccept(s ->
+            webAPI.executeScript(videoElem.getName()+".srcObject = "+s.getName()+";"));
     }
 
+    /** Displays the given (already resolved) media stream. */
     public void setStream(JSVariable stream) {
         webAPI.executeScript(videoElem.getName()+".srcObject = "+stream.getName()+";");
     }


### PR DESCRIPTION
Documents `jpro-webrtc` and cleans up its API (the module deferred earlier so docs + API could land together). Hard rename — pre-1.0.

### Docs
- New **README** (published as the `DOCUMENTATION` artifact, added to the website doc list): what the module is, the four classes, a two-peers-on-one-page example, and a section on signaling for real cross-browser apps.
- **Javadoc** on all public classes/methods (there was almost none).

### API cleanup (breaking, pre-1.0)
- **Encapsulated state:** `connectionState`/`iceConnectionState`/`iceGatheringState`/`signalingState` are now read-only `…Property()` accessors; `getTracks()`/`getIceCandidates()` replace the public `ObservableList` fields.
- **Callbacks:** `setOnNewIceCandidate(...)` / `setOnNegotiationNeeded(...)` replace the public mutable fields; `onnegotiationneeded` → `onNegotiationNeeded`.
- **`MediaStream.js` field → `js()` method.**
- **Made internal JS-wiring private** (`listenToJS`/`listenToProperty`).
- **Convenience:** `RTCPeerConnection.addStream(MediaStream)` (resolves the stream for you) — removes the repetitive `.js().thenAccept(... addStream ...)` boilerplate.
- Removed a debug `System.out.println` and commented-out dead code; consistent `addTrack`/`removeTrack` naming.

Examples updated to the new API.

**Not** in this PR (possible follow-up): hiding `JSVariable` behind typed wrappers (a `Track` type, `MediaStream` throughout) — the deeper redesign.

Verified: `:jpro-webrtc` and `:jpro-webrtc:example` compile; DOCUMENTATION artifact generates; README version in sync. Not runtime-tested — WebRTC is browser-only (needs a real browser + camera).

🤖 Generated with [Claude Code](https://claude.com/claude-code)